### PR TITLE
Revamp docs - new quickstart, how-to, gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 </div>
 
 <div class="row">
-  
+
   <a>
   <img src="./examples/image_5.png" height="250" width="375">
   </a>
@@ -45,6 +45,10 @@ Seaborn-image is a seaborn like python **image** visualization and processing li
 based on matplotlib, scipy and scikit-image.
 
 The aim of seaborn-image is to provide a high-level API to **process and plot attractive images quickly and effectively**.
+
+## Documentation
+
+Check out the docs [here](https://seaborn-image.readthedocs.io/)
 
 
 ## Installation
@@ -107,6 +111,4 @@ isns.filterplot(data, filter="gaussian", sigma=5, cbar_label="Height (nm)")
 <img src="./examples/image_3.png" height="260" width="600">
 </a>
 
-## Documentation
-
-Check out the docs [here](https://seaborn-image.readthedocs.io/)
+Check out the more information [here](https://seaborn-image.readthedocs.io/)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,2 +1,0 @@
-.. _changes:
-.. include:: ../CHANGELOG.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,10 +1,11 @@
 from datetime import datetime
+import sphinx_bootstrap_theme
 
 
 project = "seaborn-image"
 author = "Sarthak Jariwala"
 copyright = f"{datetime.now().year}, {author}"
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon"]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon", "sphinxcontrib.images"]
 html_static_path = ["_static"]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -51,12 +52,26 @@ pygments_style = "sphinx"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-# html_theme = "alabaster"
+html_theme = "bootstrap"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-# html_theme_options = {"sidebar_width": "300px", "page_width": "1200px"}
+html_theme_options = {
+    "source_link_position": "footer",
+    "bootswatch_theme": "united",  # paper, simplex
+    "navbar_sidebarrel": False,
+    "bootstrap_version": "3",
+    "navbar_links": [
+        ("Quickstart", "quickstart"),
+        ("How-to?", "how_to"),
+        ("Gallery", "gallery"),
+        ("Releases", "https://github.com/SarthakJariwala/seaborn-image/releases", True),
+        ("Reference", "reference"),
+    ],
+}
+
+html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
@@ -172,14 +187,11 @@ html_static_path = ["_static"]
 # # If false, no module index is generated.
 # # latex_domain_indices = True
 
-# # -- External mapping ------------------------------------------------------------
-# python_version = '.'.join(map(str, sys.version_info[0:2]))
-# intersphinx_mapping = {
-#     'sphinx': ('http://www.sphinx-doc.org/en/stable', None),
-#     'python': ('https://docs.python.org/' + python_version, None),
-#     'matplotlib': ('https://matplotlib.org', None),
-#     'numpy': ('https://docs.scipy.org/doc/numpy', None),
-#     'sklearn': ('http://scikit-learn.org/stable', None),
-#     'pandas': ('http://pandas.pydata.org/pandas-docs/stable', None),
-#     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
-# }
+# -- External mapping ------------------------------------------------------------
+intersphinx_mapping = {
+    "sphinx": ("http://www.sphinx-doc.org/en/stable", None),
+    "matplotlib": ("https://matplotlib.org", None),
+    "numpy": ("https://docs.scipy.org/doc/numpy", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
+    "scikit-image": ("https://scikit-image.org/", None),
+}

--- a/docs/gallery.rst
+++ b/docs/gallery.rst
@@ -1,0 +1,26 @@
+Gallery
+=======
+
+.. thumbnail:: ../examples/image_5.png
+    :width:  300px
+    :height: 200px
+
+
+.. thumbnail:: ../examples/image_1.png
+    :width:  240px
+    :height: 200px
+
+
+.. thumbnail:: ../examples/image_0.png
+    :width:  240px
+    :height: 200px
+
+
+.. thumbnail:: ../examples/image_3.png
+    :width:  450px
+    :height: 200px
+
+
+.. thumbnail:: ../examples/image_4.png
+    :width:  200px
+    :height: 200px

--- a/docs/how_to.rst
+++ b/docs/how_to.rst
@@ -1,0 +1,106 @@
+How to...?
+==========
+
+.. contents::
+    :local:
+
+
+Visualize distribution
+----------------------
+
+Add a histogram to the image
+****************************
+
+.. code-block:: python
+
+    import seaborn_image as isns
+
+    isns.imghist(data)
+
+
+Change histogram bins for the distribution
+******************************************
+
+.. code-block:: python
+
+    import seaborn_image as isns
+
+    isns.imghist(data, bins=250)
+
+
+Add and modify scale bar properties
+-----------------------------------
+
+Add a scale bar
+***************
+
+.. code-block:: python
+
+    import seaborn_image as isns
+
+    isns.imgplot(data, dx=1, units="um")
+
+
+Modify scale bar properties
+***************************
+
+.. code-block:: python
+
+    import seaborn_image as isns
+
+    # change scalebar color
+    isns.set_scalebar(rc={"color": "red"})
+
+    # change scalebar position
+    isns.set_scalebar(rc={"location": "upper right"})
+
+
+Add label to colorbar
+---------------------
+
+.. code-block:: python
+
+    import seaborn_image as isns
+
+    isns.imgplot(data, cbar_label="Intensity (au)")
+
+
+Use image filters
+-----------------
+
+.. code-block:: python
+
+    import seaborn_image as isns
+
+    isns.filterplot(data, filter="sobel")
+
+
+Change image plot properties
+----------------------------
+
+.. code-block:: python
+
+    import seaborn_image as isns
+
+    isns.set_image(cmap="inferno", origin="upper")
+
+
+General aesthetics
+------------------
+
+.. code-block:: python
+
+    import seaborn_image as isns
+
+    isns.set_context("paper") # or talk, notebook, presentation, poster
+
+    # change font-family
+    isns.set_context(fontfamily="sans-serif")
+
+Arbitrary ``matplotlib`` rcParams can also be altered by passing them as
+a dict to ``rc`` parameter.
+
+.. code-block:: python
+
+    # change axes title pad
+    isns.set_context(rc={"axes.titlepad": 6})

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,38 +4,51 @@ seaborn-image: image data visualization
 
 .. list-table::
 
-    * - .. image:: ../examples/image_0.png
+    * - .. image:: ../examples/image_1.png
             :width: 150px
             :height: 140px
 
-        .. image:: ../examples/image_1.png
-            :width: 150px
+        .. image:: ../examples/image_5.png
+            :width: 200px
             :height: 140px
 
-        .. image:: ../examples/image_3.png
-            :width: 320px
-            :height: 150px
-
-
-Seaborn like image data visualization using matplotlib, scikit-image and scipy.
+        .. image:: ../examples/image_4.png
+            :width:  140px
+            :height: 140px
 
 
 Description
 ===========
 
-Seaborn-image is a seaborn like python **image** visualization and processing library
-based on matplotlib.
+Seaborn-image is a *seaborn like* Python **image** visualization and processing library
+based on matplotlib, scikit-image and scipy.
 
 The aim of seaborn-image is to provide a high-level API to **process and plot attractive images quickly**
 **and effectively**.
+
+To get started with ``seaborn_image``, check out the :doc:`quickstart page <quickstart>`.
+To view example images, check out the :doc:`gallery page <gallery>`.
+For specific how-to questions, refer to the :doc:`how-to page <how_to>`.
+
+Check out the source code on `github <https://github.com/SarthakJariwala/seaborn-image>`_.
+If you come across any bugs, please open an `issue <https://github.com/SarthakJariwala/seaborn-image/issues>`_.
 
 
 Installation
 ============
 
-``pip install seaborn-image``
+.. code-block:: bash
+
+    pip install seaborn-image
+
+Usage
+=====
+
+Check out the :doc:`quickstart page <quickstart>` for a walk through
+of the sample features below.
 
 Simple usage
+************
 
 .. code-block:: python
 
@@ -51,6 +64,7 @@ Simple usage
     isns.imgplot(data, dx=1, units="um")
 
 Apply image filters (from scipy and skimage) and plot
+*****************************************************
 
 .. code-block:: python
 
@@ -59,12 +73,18 @@ Apply image filters (from scipy and skimage) and plot
     isns.filterplot(data, filter="gaussian")
 
 
+For more information on getting strated, refer to the :doc:`quickstart guide <quickstart>`.
+
+
 Contents
 ========
 
 .. toctree::
    :maxdepth: 1
 
+   Quickstart <quickstart>
+   How-to? <how_to>
+   Gallery <gallery>
    License <license>
    Authors <authors>
    Changelog <https://github.com/SarthakJariwala/seaborn-image/releases>

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,0 +1,114 @@
+==========
+Quickstart
+==========
+
+.. contents::
+    :local:
+
+
+Installation
+------------
+
+You can install ``seaborn-image`` using ``pip``.
+
+.. code-block:: bash
+
+    pip install seaborn-image
+
+
+Basic Usage
+-----------
+
+Basic image data visualization using ``imgplot``
+************************************************
+
+.. code-block:: python
+
+    import seaborn_image as isns
+    import numpy as np # for loading data
+
+    # Load data
+    data = np.loadtxt("PolymerImage.txt")
+
+    # Plot
+    isns.imgplot(data)
+
+
+Add a scalebar to the image
+***************************
+
+.. code-block:: python
+
+    # specify the size-per-pixel (dx) and the units for the scalebar
+
+    isns.imgplot(data, dx=15, units="nm")
+
+In the ``imgplot`` function, you can add a scalebar by specifying
+the size-per-pixel (``dx``) and the units (``units``).
+
+Here, we are specifying ``dx = 0.015`` and ``units = 'um'``.
+This means that the physical size per pixel is "0.015 um".
+You can also specify the same by specifying ``dx = 15`` and ``units= 'nm'``.
+This will also give you the same scalebar.
+
+Add a label to the colorbar
+***************************
+
+.. code-block:: python
+
+    # specify the colorbar label using cbar_label
+
+    isns.imgplot(data, dx=15, units="nm", cbar_label="Height (nm)")
+
+.. image:: ../examples/image_0.png
+    :width: 400px
+    :height: 360px
+
+
+Visualize the distribution of the data using ``imghist``
+********************************************************
+
+You can also visualize the image data distribution alongside the image
+and its colorbar using ``imghist`` function
+
+.. code-block:: python
+
+    # Plot distribution alongside the image
+
+    isns.imghist(data, dx=15, units="nm", cbar_label="Height (nm)", cmap="ice")
+
+.. image:: ../examples/image_5.png
+    :width: 600px
+    :height: 400px
+
+You can also change the number of bins in the distribution using ``bins`` parameter
+in ``imghist``. In the above example, we also changed the colormap to 'ice'
+using ``cmap = 'ice'``. This is one of the inbuilt colormaps in ``seaborn_image``.
+You can also use a ``matplotlib`` colormap - ``cmap = "viridis"``.
+
+
+Apply image filters from scipy and skimage using ``filterplot``
+***************************************************************
+
+You can also process images using scipy and scikit-image filters
+and visualize them with minimal effort. This can be done using ``filterplot``
+in ``seaborn_image``.
+
+This is as simple as :
+
+.. code-block:: python
+
+    isns.filterplot(data, filter="sobel") # default is gaussian
+
+All the previous customizations such as scalebar, colorbar, etc.
+can be applied in the same way as before. Additionally, you can also view the
+fast-fourier transform of the original and filtered image simply by setting
+``fft = True`` :
+
+.. code-block:: python
+
+    isns.filterplot(data, filter="diff_of_gaussians", fft=True, dx=15, units="nm")
+
+.. image:: ../examples/image_4.png
+    :width:  600px
+    :height: 600px

--- a/noxfile.py
+++ b/noxfile.py
@@ -81,6 +81,6 @@ def safety(session):
 @nox.session()
 def docs(session):
     """Build the documentation."""
-    session.run("poetry", "install", "--no-dev", external=True)
+    session.run("poetry", "install", external=True)
     install_with_constraints(session, "sphinx")
     session.run("sphinx-build", "docs", "docs/_build")

--- a/poetry.lock
+++ b/poetry.lock
@@ -122,7 +122,7 @@ requests = ">=2.7.9"
 [[package]]
 category = "dev"
 description = "Cross-platform colored terminal text."
-marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
+marker = "sys_platform == \"win32\" or platform_system == \"Windows\" or python_version >= \"3.0\" and sys_platform == \"win32\""
 name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
@@ -766,6 +766,17 @@ test = ["pytest", "pytest-cov", "html5lib", "typed-ast", "cython"]
 
 [[package]]
 category = "dev"
+description = "Sphinx Bootstrap Theme."
+name = "sphinx-bootstrap-theme"
+optional = false
+python-versions = "*"
+version = "0.7.1"
+
+[package.dependencies]
+setuptools = "*"
+
+[[package]]
+category = "dev"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
 name = "sphinxcontrib-applehelp"
 optional = false
@@ -799,6 +810,21 @@ version = "1.0.3"
 [package.extras]
 lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest", "html5lib"]
+
+[[package]]
+category = "dev"
+description = "Sphinx extension for thumbnails"
+name = "sphinxcontrib-images"
+optional = false
+python-versions = "*"
+version = "0.9.2"
+
+[package.dependencies]
+requests = ">2.2,<3"
+
+[package.dependencies.sphinx]
+python = ">=3.0"
+version = ">=2.0"
 
 [[package]]
 category = "dev"
@@ -915,7 +941,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "07d9a60ca8661dc2e490efb3cb71c004533eff25affa72bede2310651427a337"
+content-hash = "9fc18982c71ccbc41a99e59a570c9a236b0d2de1a7dbebe6d5f7a38aa7a962e0"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -1396,6 +1422,9 @@ sphinx = [
     {file = "Sphinx-3.1.2-py3-none-any.whl", hash = "sha256:97dbf2e31fc5684bb805104b8ad34434ed70e6c588f6896991b2fdfd2bef8c00"},
     {file = "Sphinx-3.1.2.tar.gz", hash = "sha256:b9daeb9b39aa1ffefc2809b43604109825300300b987a24f45976c001ba1a8fd"},
 ]
+sphinx-bootstrap-theme = [
+    {file = "sphinx-bootstrap-theme-0.7.1.tar.gz", hash = "sha256:571e43ccb76d4c6c06576aa24a826b6ebc7adac45a5b54985200128806279d08"},
+]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},
     {file = "sphinxcontrib_applehelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a"},
@@ -1407,6 +1436,10 @@ sphinxcontrib-devhelp = [
 sphinxcontrib-htmlhelp = [
     {file = "sphinxcontrib-htmlhelp-1.0.3.tar.gz", hash = "sha256:e8f5bb7e31b2dbb25b9cc435c8ab7a79787ebf7f906155729338f3156d93659b"},
     {file = "sphinxcontrib_htmlhelp-1.0.3-py2.py3-none-any.whl", hash = "sha256:3c0bc24a2c41e340ac37c85ced6dafc879ab485c095b1d65d2461ac2f7cca86f"},
+]
+sphinxcontrib-images = [
+    {file = "sphinxcontrib-images-0.9.2.tar.gz", hash = "sha256:f0d5d720b69789c83bf1e6925093b32ab4cd6f925d24ecded56109fc0d0eb174"},
+    {file = "sphinxcontrib_images-0.9.2-py2.py3-none-any.whl", hash = "sha256:db8d1b9cec0b71ba59ce1919d199a7d121bb7b916e96fb883c4f97b3f6bc6241"},
 ]
 sphinxcontrib-jsmath = [
     {file = "sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ pytest-cov = "^2.10.0"
 flake8-docstrings = "^1.5.0"
 sphinx = "^3.1.2"
 codecov = "^2.1.8"
+sphinx_bootstrap_theme = "^0.7.1"
+sphinxcontrib-images = "^0.9.2"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
- New quickstart guide
- New how-to guide 
- New example gallery (new dev dependency - `sphinxcontrib-images`)
- Bootstrap theme for doc site (new dev dependency - `sphinx_bootstrap_theme`)
- Intro page updated  
- Minor readme changes

- Use dev mode in docs noxsession