### PR TITLE
Add `dimension` parameter for scale bar to all plot functions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.3.1
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v2.1.1
         with:
           python-version: ${{ matrix.python-version }}
           # architecture: x64

--- a/src/seaborn_image/_core.py
+++ b/src/seaborn_image/_core.py
@@ -5,6 +5,15 @@ from mpl_toolkits.axes_grid1 import axes_size, make_axes_locatable
 
 from ._colormap import _CMAP_QUAL
 
+# dimensions for scalebar
+_DIMENSIONS = {
+    "si": "si-length",
+    "si-reciprocal": "si-length-reciprocal",
+    "imperial": "imperial-length",
+    "angle": "angle",
+    "pixel": "pixel-length",
+}
+
 
 def _check_dict(dictionary):
     if not isinstance(dictionary, dict):
@@ -23,6 +32,7 @@ class _SetupImage(object):
         fontdict=None,
         dx=None,
         units=None,
+        dimension=None,
         cbar=None,
         cbar_fontdict=None,
         cbar_label=None,
@@ -39,6 +49,7 @@ class _SetupImage(object):
         self.fontdict = fontdict
         self.dx = dx
         self.units = units
+        self.dimension = dimension
         self.cbar = cbar
         self.cbar_fontdict = cbar_fontdict
         self.cbar_label = cbar_label
@@ -75,7 +86,16 @@ class _SetupImage(object):
                     "'units' must be specified when 'dx' (scalebar) is used"
                 )
 
-        scalebar = ScaleBar(dx=dx, units=units)
+        if self.dimension is None:
+            _dimension = _DIMENSIONS.get("si")
+        elif self.dimension in _DIMENSIONS.keys():
+            _dimension = _DIMENSIONS.get(self.dimension)
+        else:
+            raise ValueError(
+                f"Unsupported dimension. Supported dimensions are : {_DIMENSIONS.keys()}"
+            )
+
+        scalebar = ScaleBar(dx=dx, units=units, dimension=_dimension)
 
         ax.add_artist(scalebar)
 

--- a/src/seaborn_image/_filters.py
+++ b/src/seaborn_image/_filters.py
@@ -16,6 +16,7 @@ def filterplot(
     vmax=None,
     dx=None,
     units=None,
+    dimension=None,
     cbar=True,
     cbar_label=None,
     cbar_fontdict=None,
@@ -47,6 +48,14 @@ def filterplot(
         dx (float, optional): Size per pixel of the image data. If scalebar
             is required, `dx` and `units` must be sepcified. Defaults to None.
         units (str, optional): Units of `dx`. Defaults to None.
+        dimension (str, optional): dimension of `dx` and `units`.
+            Options include :
+                - "si" : scale bar showing km, m, cm, etc.
+                - "imperial" : scale bar showing in, ft, yd, mi, etc.
+                - "si-reciprocal" : scale bar showing 1/m, 1/cm, etc.
+                - "angle" : scale bar showing °, ʹ (minute of arc) or ʹʹ (second of arc).
+                - "pixel" : scale bar showing px, kpx, Mpx, etc.
+            Defaults to None.
         cbar (bool, optional): Specify if a colorbar is required or not.
             Defaults to True.
         cbar_label (str, optional): Colorbar label. Defaults to None.
@@ -160,6 +169,7 @@ def filterplot(
             vmax=vmax,
             dx=dx,
             units=units,
+            dimension=dimension,
             cbar=cbar,
             cbar_label=cbar_label,
             cbar_fontdict=cbar_fontdict,
@@ -176,6 +186,7 @@ def filterplot(
             vmax=vmax,
             dx=dx,
             units=units,
+            dimension=dimension,
             cbar=cbar,
             cbar_label=cbar_label,
             cbar_fontdict=cbar_fontdict,
@@ -214,6 +225,7 @@ def filterplot(
             vmax=vmax,
             dx=dx,
             units=units,
+            dimension=dimension,
             cbar=cbar,
             cbar_label=cbar_label,
             cbar_fontdict=cbar_fontdict,
@@ -230,6 +242,7 @@ def filterplot(
             vmax=vmax,
             dx=dx,
             units=units,
+            dimension=dimension,
             cbar=cbar,
             cbar_label=cbar_label,
             cbar_fontdict=cbar_fontdict,

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -16,6 +16,7 @@ def imgplot(
     vmax=None,
     dx=None,
     units=None,
+    dimension=None,
     cbar=True,
     cbar_label=None,
     cbar_fontdict=None,
@@ -41,6 +42,14 @@ def imgplot(
         dx (float, optional): Size per pixel of the image data. If scalebar
             is required, `dx` and `units` must be sepcified. Defaults to None.
         units (str, optional): Units of `dx`. Defaults to None.
+        dimension (str, optional): dimension of `dx` and `units`.
+            Options include (similar to `matplotlib_scalebar`):
+                - "si" : scale bar showing km, m, cm, etc.
+                - "imperial" : scale bar showing in, ft, yd, mi, etc.
+                - "si-reciprocal" : scale bar showing 1/m, 1/cm, etc.
+                - "angle" : scale bar showing °, ʹ (minute of arc) or ʹʹ (second of arc).
+                - "pixel" : scale bar showing px, kpx, Mpx, etc.
+            Defaults to None.
         cbar (bool, optional): Specify if a colorbar is required or not.
             Defaults to True.
         cbar_label (str, optional): Colorbar label. Defaults to None.
@@ -110,6 +119,7 @@ def imgplot(
         vmax=vmax,
         dx=dx,
         units=units,
+        dimension=dimension,
         cbar=cbar,
         cbar_label=cbar_label,
         cbar_fontdict=cbar_fontdict,
@@ -132,6 +142,7 @@ def imghist(
     vmax=None,
     dx=None,
     units=None,
+    dimension=None,
     cbar=True,
     cbar_label=None,
     cbar_fontdict=None,
@@ -155,6 +166,14 @@ def imghist(
         dx (float, optional): Size per pixel of the image data. If scalebar
             is required, `dx` and `units` must be sepcified. Defaults to None.
         units (str, optional): Units of `dx`. Defaults to None.
+        dimension (str, optional): dimension of `dx` and `units`.
+            Options include :
+                - "si" : scale bar showing km, m, cm, etc.
+                - "imperial" : scale bar showing in, ft, yd, mi, etc.
+                - "si-reciprocal" : scale bar showing 1/m, 1/cm, etc.
+                - "angle" : scale bar showing °, ʹ (minute of arc) or ʹʹ (second of arc).
+                - "pixel" : scale bar showing px, kpx, Mpx, etc.
+            Defaults to None.
         cbar (bool, optional): Specify if a colorbar is required or not.
             Defaults to True.
         cbar_label (str, optional): Colorbar label. Defaults to None.
@@ -204,6 +223,7 @@ def imghist(
         vmax=vmax,
         dx=dx,
         units=units,
+        dimension=dimension,
         cbar=cbar,
         cbar_label=cbar_label,
         cbar_fontdict=cbar_fontdict,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -102,3 +102,5 @@ def test_plot_w_all_inputs(
         assert isinstance(cax, Axes)
     else:
         assert cax is None
+
+    plt.close("all")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -31,6 +31,15 @@ def test_setup_scalebar():
         img_setup._setup_scalebar(ax)
 
 
+def test_setup_scalebar_dimension():
+    with pytest.raises(ValueError):
+        img_setup = isns._core._SetupImage(
+            data, dx=1, units="nm", dimension="imperial-reciprocal"
+        )
+        f, ax = img_setup._setup_figure()
+        img_setup._setup_scalebar(ax)
+
+
 def test_plot_check_cbar_dict():
     with pytest.raises(TypeError):
         img_setup = isns._core._SetupImage(
@@ -48,6 +57,7 @@ def test_plot_check_cbar_dict():
 @pytest.mark.parametrize(
     "units", ["m", "um"]
 )  # units can't be None when dx is not None
+@pytest.mark.parametrize("dimension", [None, "si"])
 @pytest.mark.parametrize("cbar", [None, True, False])
 @pytest.mark.parametrize("cbar_fontdict", [None, {"fontsize": 20}])
 @pytest.mark.parametrize("cbar_label", [None, "Cbar Label"])
@@ -61,6 +71,7 @@ def test_plot_w_all_inputs(
     fontdict,
     dx,
     units,
+    dimension,
     cbar,
     cbar_fontdict,
     cbar_label,
@@ -76,6 +87,7 @@ def test_plot_w_all_inputs(
         fontdict=fontdict,
         dx=dx,
         units=units,
+        dimension=dimension,
         cbar=cbar,
         cbar_fontdict=cbar_fontdict,
         cbar_label=cbar_label,

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -16,7 +16,7 @@ def test_filter_not_implemented():
 
 
 @pytest.mark.parametrize(
-    "filter,fft", [(["gaussian"], True), ("gaussian", "True"), (["gaussian"], "True")]
+    "filter,fft", [(["gaussian"], True), ("gaussian", "True"), (["gaussian"], None)]
 )
 def test_filter_types(filter, fft):
     with pytest.raises(TypeError):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,5 +1,6 @@
 import pytest
 
+import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
@@ -34,3 +35,5 @@ def test_filters(filter, fft):
     assert isinstance(ax, np.ndarray)
     assert isinstance(ax.ravel().all(), Axes)
     assert filt_data.all() == data.all()
+
+    plt.close("all")

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -68,7 +68,7 @@ def test_imgplot_return():
 def test_imgplot_w_all_valid_inputs(
     cmap, cbar, cbar_label, cbar_fontdict, showticks, title, title_fontdict
 ):
-    isns.imgplot(
+    f, ax, cax = isns.imgplot(
         data,
         ax=None,
         cmap=cmap,
@@ -79,6 +79,7 @@ def test_imgplot_w_all_valid_inputs(
         title=title,
         title_fontdict=title_fontdict,
     )
+    plt.close("all")
 
 
 @pytest.mark.parametrize("bins", [None, 200.0, -400.13])
@@ -113,7 +114,7 @@ def test_imghist_return():
 def test_imghist_w_all_valid_inputs(
     cmap, bins, cbar, cbar_label, cbar_fontdict, showticks, title, title_fontdict
 ):
-    isns.imghist(
+    f, axes, cax = isns.imghist(
         data,
         cmap=cmap,
         bins=bins,
@@ -124,3 +125,5 @@ def test_imghist_w_all_valid_inputs(
         title=title,
         title_fontdict=title_fontdict,
     )
+
+    plt.close("all")


### PR DESCRIPTION
- `dimension` can now be specified in all plot functions

This was already implemented in [matplotlib_scalebar](https://github.com/ppinard/matplotlib-scalebar). Now available in [seaborn_image](https://seaborn-image.readthedocs.io/)

For example - 

```python
import seaborn_image as isns

isns.imgplot(data, dx=1, units="ft", dimension="imperial") # default is "si"
# options include "si", "si-reciprocal", "imperial",  "angle", "pixel"