### PR TITLE
seaborn-image cmaps can now be set globally using `set_image`

### DIFF
--- a/src/seaborn_image/_context.py
+++ b/src/seaborn_image/_context.py
@@ -1,5 +1,6 @@
 import matplotlib as mpl
 import matplotlib.pyplot as plt
+from matplotlib.cm import register_cmap
 
 from ._colormap import _CMAP_QUAL
 
@@ -82,7 +83,7 @@ def reset_defaults():
     mpl.rcParams.update(mpl.rcParamsDefault)
 
 
-def set_image(cmap="viridis", origin="lower", interpolation="nearest"):
+def set_image(cmap="ice", origin="lower", interpolation="nearest"):
     """
     Set deaults for plotting images
 
@@ -101,7 +102,9 @@ def set_image(cmap="viridis", origin="lower", interpolation="nearest"):
     """
 
     if cmap in _CMAP_QUAL.keys():  # doesn't work currently
-        cmap = _CMAP_QUAL.get(cmap).mpl_colormap
+        cmap_mpl = _CMAP_QUAL.get(cmap).mpl_colormap
+        register_cmap(name=cmap, cmap=cmap_mpl)
+
     plt.rc("image", cmap=cmap, origin=origin, interpolation=interpolation)
 
 

--- a/src/seaborn_image/_core.py
+++ b/src/seaborn_image/_core.py
@@ -102,9 +102,7 @@ class _SetupImage(object):
     def plot(self):
         f, ax = self._setup_figure()
 
-        if self.cmap is None:  # TODO move default to _context
-            self.cmap = _CMAP_QUAL.get("deep").mpl_colormap
-        elif self.cmap in _CMAP_QUAL.keys():
+        if self.cmap in _CMAP_QUAL.keys():
             self.cmap = _CMAP_QUAL.get(self.cmap).mpl_colormap
 
         _map = ax.imshow(self.data, cmap=self.cmap, vmin=self.vmin, vmax=self.vmax)

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import gridspec
 from matplotlib.axes import Axes
+from matplotlib.cm import get_cmap
 from matplotlib.colors import Colormap
 
 from ._colormap import _CMAP_QUAL
@@ -244,7 +245,8 @@ def imghist(
     ax2.set_frame_on(False)
 
     if cmap is None:
-        cm = _CMAP_QUAL.get("deep").mpl_colormap
+        # cm = _CMAP_QUAL.get("deep").mpl_colormap
+        cm = get_cmap()
     else:
         if cmap in _CMAP_QUAL.keys():
             cm = _CMAP_QUAL.get(cmap).mpl_colormap

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -33,10 +33,9 @@ def test_set_save_context(dpi):
     assert mpl.rcParams["savefig.bbox"] == "tight"
 
 
-@pytest.mark.parametrize(
-    "cmap,origin,interpolation",
-    [("viridis", "lower", "nearest"), ("afmhot", "upper", "bicubic")],
-)
+@pytest.mark.parametrize("cmap", ["ice", "acton", "viridis", "afmhot"])
+@pytest.mark.parametrize("origin", ["lower", "upper"])
+@pytest.mark.parametrize("interpolation", ["nearest", "bicubic"])
 def test_set_image(cmap, origin, interpolation):
     isns.set_image(cmap, origin, interpolation)
 


### PR DESCRIPTION
- `set_image()` function now also changes and registers seaborn-image colormaps
- default cmap is 'ice', set globally upon import
- Note : this will change the default for any matplotlib figure until `reset_defaults()`is called to set it to matplotlib default viridis. This can, of course, also be done using `set_image(cmap="viridis")`

Example:
```python
isns.set_image(cmap="acton") # use seaborn-image colormaps
isns.set_iamge(cmap="viridis") # matplotlib colormaps work as usual