### PR TITLE
control colorbar orientation, despine by default, sci ticks

### DIFF
--- a/src/seaborn_image/__init__.py
+++ b/src/seaborn_image/__init__.py
@@ -6,6 +6,7 @@ except ImportError:  # pragma: no cover
 from ._context import *
 from ._general import *
 from ._filters import *
+from .utils import *
 
 
 set_context()

--- a/src/seaborn_image/_context.py
+++ b/src/seaborn_image/_context.py
@@ -4,6 +4,14 @@ from matplotlib.cm import register_cmap
 
 from ._colormap import _CMAP_QUAL
 
+__all__ = [
+    "set_context",
+    "set_save_context",
+    "reset_defaults",
+    "set_image",
+    "set_scalebar",
+]
+
 # TODO implement a set() fuction for all underlying set_*
 
 
@@ -108,7 +116,7 @@ def set_image(cmap="ice", origin="lower", interpolation="nearest"):
     plt.rc("image", cmap=cmap, origin=origin, interpolation=interpolation)
 
 
-def set_scalebar(rc=None):
+def set_scalebar(rc=None):  # TODO re-write input as individual kwargs instead of dict
     """Set scalebar properties such as color, scale_loc,
     height_fraction, length_fraction, box_alpha, etc
 

--- a/src/seaborn_image/_filters.py
+++ b/src/seaborn_image/_filters.py
@@ -7,6 +7,8 @@ from skimage.filters import difference_of_gaussians, window
 
 from ._general import imgplot
 
+__all__ = ["filterplot"]
+
 
 def filterplot(
     data,

--- a/src/seaborn_image/_filters.py
+++ b/src/seaborn_image/_filters.py
@@ -103,18 +103,9 @@ def filterplot(
         raise TypeError
 
     # kwargs across filters
-    axis = kwargs.get("axis", -1)
-    mode = kwargs.get("mode", "reflect")
-    cval = kwargs.get("cval", 0.0)
     size = kwargs.get("size", 5)
-    footprint = kwargs.get("footprint", None)
-    origin = kwargs.get("origin", 0)
     sigma = kwargs.get("sigma", 1)
-    order = kwargs.get("order", 0)
-    truncate = kwargs.get("truncate", 4.0)
-    multichannel = kwargs.get("multichannel", False)
     low_sigma = kwargs.get("low_sigma", 1)
-    high_sigma = kwargs.get("high_sigma", None)
 
     _implemented_filters = ["sobel", "gaussian", "median", "max", "diff_of_gaussians"]
 
@@ -125,37 +116,20 @@ def filterplot(
 
     else:
         if filter == "sobel":
-            filtered_data = ndi.sobel(data, axis=axis, mode=mode, cval=cval)
+            filtered_data = ndi.sobel(data, **kwargs)
 
         elif filter == "gaussian":
-            filtered_data = ndi.gaussian_filter(
-                data, sigma=sigma, order=order, mode=mode, cval=cval, truncate=truncate
-            )
+            filtered_data = ndi.gaussian_filter(data, sigma=sigma, **kwargs)
 
         elif filter == "median":
-            filtered_data = ndi.median_filter(
-                data, size=size, mode=mode, cval=cval, origin=origin
-            )
+            filtered_data = ndi.median_filter(data, size=size, **kwargs)
 
         elif filter == "max":
-            filtered_data = ndi.maximum_filter(
-                data,
-                size=size,
-                footprint=footprint,
-                mode=mode,
-                cval=cval,
-                origin=origin,
-            )
+            filtered_data = ndi.maximum_filter(data, size=size, **kwargs)
 
         elif filter == "diff_of_gaussians":
             filtered_data = difference_of_gaussians(
-                data,
-                low_sigma=low_sigma,
-                high_sigma=high_sigma,
-                mode=kwargs.get("mode", "nearest"),
-                cval=cval,
-                multichannel=multichannel,
-                truncate=truncate,
+                data, low_sigma=low_sigma, **kwargs,
             )
 
     if fft:  # move to FacetGrid like in seaborn (?) TODO

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -9,6 +9,8 @@ from matplotlib.colors import Colormap
 from ._colormap import _CMAP_QUAL
 from ._core import _SetupImage
 
+__all__ = ["imgplot", "imghist"]
+
 
 def imgplot(
     data,
@@ -21,10 +23,12 @@ def imgplot(
     dimension=None,
     describe=True,
     cbar=True,
+    orientation="v",
     cbar_label=None,
     cbar_fontdict=None,
     cbar_ticks=None,
     showticks=False,
+    despine=True,
     title=None,
     title_fontdict=None,
 ):
@@ -57,6 +61,11 @@ def imgplot(
             Defaults to True.
         cbar (bool, optional): Specify if a colorbar is required or not.
             Defaults to True.
+        orientation (str, optional): Specify the orientaion of colorbar.
+            Option include :
+                - 'h' or 'horizontal' for a horizontal colorbar to the bottom of the image.
+                - 'v' or 'vertical' for a vertical colorbar to the right of the image.
+            Defaults to 'v'.
         cbar_label (str, optional): Colorbar label. Defaults to None.
         cbar_fontdict (dict, optional): Font specifications for colorbar label - `cbar_label`.
             Defaults to None.
@@ -64,6 +73,8 @@ def imgplot(
             the data are used. If `vmin` and `vmax` are specified, `vmin` and `vmax` values
             are used for colorbar ticks. Defaults to None.
         showticks (bool, optional): Show image x-y axis ticks. Defaults to False.
+        despine (bool, optional): Remove axes spines from image axes as well as colorbar axes.
+            Defaults to True.
         title (str, optional): Image title. Defaults to None.
         title_fontdict (dict, optional): [Font specifications for `title`. Defaults to None.
 
@@ -71,9 +82,11 @@ def imgplot(
         TypeError: if `cmap` is not str or `matplotlib.colors.Colormap`
         TypeError: if `ax` is not `matplotlib.axes.Axes`
         TypeError: if `cbar` is not bool
+        TypeError: if `orientation` is not str
         TypeError: if `cbar_label` is not str
         TypeError: if `cbar_fontdict` is not dict
         TypeError: if `showticks` is not bool
+        TypeError: if `despine` is not bool
         TypeError: if `title` is not str
         TypeError: if `title_fontdict` is not dict
 
@@ -96,24 +109,38 @@ def imgplot(
     if cmap is not None:
         if not isinstance(cmap, (str, Colormap)):
             raise TypeError
+
     if ax is not None:
         if not isinstance(ax, Axes):
             raise TypeError
+
     if not isinstance(describe, bool):
         raise TypeError
+
     if not isinstance(cbar, bool):
         raise TypeError
+
+    if not isinstance(orientation, str):
+        raise TypeError
+
     if cbar_label is not None:
         if not isinstance(cbar_label, str):
             raise TypeError
+
     if cbar_fontdict is not None:
         if not isinstance(cbar_fontdict, dict):
             raise TypeError
+
     if not isinstance(showticks, bool):
         raise TypeError
+
+    if not isinstance(despine, bool):
+        raise TypeError
+
     if title is not None:
         if not isinstance(title, str):
             raise TypeError
+
     if title_fontdict is not None:
         if not isinstance(title_fontdict, dict):
             raise TypeError
@@ -128,10 +155,12 @@ def imgplot(
         units=units,
         dimension=dimension,
         cbar=cbar,
+        orientation=orientation,
         cbar_label=cbar_label,
         cbar_fontdict=cbar_fontdict,
         cbar_ticks=cbar_ticks,
         showticks=showticks,
+        despine=despine,
         title=title,
         fontdict=title_fontdict,
     )
@@ -161,10 +190,12 @@ def imghist(
     dimension=None,
     describe=True,
     cbar=True,
+    orientation="v",
     cbar_label=None,
     cbar_fontdict=None,
     cbar_ticks=None,
     showticks=False,
+    despine=True,
     title=None,
     title_fontdict=None,
 ):
@@ -196,6 +227,11 @@ def imghist(
             Defaults to True.
         cbar (bool, optional): Specify if a colorbar is required or not.
             Defaults to True.
+        orientation (str, optional): Specify the orientaion of colorbar.
+            Option include :
+                - 'h' or 'horizontal' for a horizontal colorbar and histogram to the bottom of the image.
+                - 'v' or 'vertical' for a vertical colorbar and histogram to the right of the image.
+            Defaults to 'v'.
         cbar_label (str, optional): Colorbar label. Defaults to None.
         cbar_fontdict (dict, optional): Font specifications for colorbar label - `cbar_label`.
             Defaults to None.
@@ -203,6 +239,8 @@ def imghist(
             the data are used. If `vmin` and `vmax` are specified, `vmin` and `vmax` values
             are used for colorbar ticks. Defaults to None.
         showticks (bool, optional): Show image x-y axis ticks. Defaults to False.
+        despine (bool, optional): Remove axes spines from image axes as well as colorbar axes.
+            Defaults to True.
         title (str, optional): Image title. Defaults to None.
         title_fontdict (dict, optional): [Font specifications for `title`. Defaults to None.
 
@@ -233,8 +271,20 @@ def imghist(
         if not bins > 0:
             raise ValueError("'bins' must be a positive integer")
 
-    f = plt.figure(figsize=(10, 6))  # TODO make figsize user defined
-    gs = gridspec.GridSpec(1, 2, width_ratios=[5, 1], figure=f)
+    if orientation in ["v", "vertical"]:
+        orientation = "vertical"  # matplotlib doesn't support 'v'
+        f = plt.figure(figsize=(10, 6))  # TODO make figsize user defined
+        gs = gridspec.GridSpec(1, 2, width_ratios=[5, 1], figure=f)
+
+    elif orientation in ["h", "horizontal"]:
+        orientation = "horizontal"  # matplotlib doesn't support 'h'
+        f = plt.figure(figsize=(6, 10))  # TODO make figsize user defined
+        gs = gridspec.GridSpec(2, 1, height_ratios=[5, 1], figure=f)
+
+    else:
+        raise ValueError(
+            "'orientation' must be either : 'horizontal' or 'h' / 'vertical' or 'v'"
+        )
 
     ax1 = f.add_subplot(gs[0])
 
@@ -249,26 +299,38 @@ def imghist(
         dimension=dimension,
         describe=describe,
         cbar=cbar,
+        orientation=orientation,
         cbar_label=cbar_label,
         cbar_fontdict=cbar_fontdict,
         cbar_ticks=cbar_ticks,
         showticks=showticks,
+        despine=despine,
         title=title,
         title_fontdict=title_fontdict,
     )
 
-    ax2 = f.add_subplot(gs[1], sharey=cax)
+    if orientation == "vertical":
+        ax2 = f.add_subplot(gs[1], sharey=cax)
 
-    n, bins, patches = ax2.hist(
-        data.ravel(), bins=bins, density=True, orientation="horizontal"
-    )
+        n, bins, patches = ax2.hist(
+            data.ravel(), bins=bins, density=True, orientation="horizontal"
+        )
 
-    ax2.get_xaxis().set_visible(False)
-    ax2.get_yaxis().set_visible(False)
-    ax2.set_frame_on(False)
+    elif orientation == "horizontal":
+        ax2 = f.add_subplot(gs[1], sharex=cax)
+
+        n, bins, patches = ax2.hist(
+            data.ravel(), bins=bins, density=True, orientation="vertical"
+        )
+
+    if not showticks:
+        ax2.get_xaxis().set_visible(False)
+        ax2.get_yaxis().set_visible(False)
+
+    if despine:
+        ax2.set_frame_on(False)
 
     if cmap is None:
-        # cm = _CMAP_QUAL.get("deep").mpl_colormap
         cm = get_cmap()
     else:
         if cmap in _CMAP_QUAL.keys():

--- a/src/seaborn_image/utils.py
+++ b/src/seaborn_image/utils.py
@@ -1,0 +1,47 @@
+import matplotlib.pyplot as plt
+from matplotlib import ticker
+
+__all__ = ["scientific_ticks", "despine"]
+
+
+def scientific_ticks(ax):
+    formatter = ticker.ScalarFormatter(useMathText=True)
+    formatter.set_scientific(True)
+    # formatter.set_powerlimits((-1,1))
+    ax.yaxis.set_major_formatter(formatter)
+
+
+def despine(fig=None, ax=None, which="all"):
+    if fig is None and ax is None:
+        axes = plt.gcf().axes
+    elif fig is not None:
+        axes = fig.axes
+    elif ax is not None:
+        axes = [ax]
+
+    _all = ["top", "bottom", "right", "left"]
+
+    if isinstance(which, str):
+        if which == "all":
+            _to_despine = _all
+        elif which in _all:
+            _to_despine = [which]
+        else:
+            raise ValueError(
+                f"Specify spine that is to be despined from the following : {_all.append('all')}"
+            )
+
+    elif isinstance(which, list):
+        _to_despine = []
+        for _which in which:
+            if _which in _all:
+                _to_despine.append(_which)
+
+    else:
+        raise TypeError(
+            f"{which} must be of the type 'str' or 'list'. Options are : {_all.append('all')}"
+        )
+
+    for ax in axes:
+        for spine in _to_despine:
+            ax.spines[spine].set_visible(False)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -58,55 +58,45 @@ def test_plot_check_cbar_dict():
         f, ax, cax = img_setup.plot()
 
 
-@pytest.mark.parametrize("cmap", [None, "acton"])
-@pytest.mark.parametrize("vmin", [None])
-@pytest.mark.parametrize("vmax", [None])
-@pytest.mark.parametrize("title", [None, "My Title"])
-@pytest.mark.parametrize("fontdict", [None, {"fontsize": 20}])
-@pytest.mark.parametrize("dx", [None, 1])
+def test_data_plotted_is_same_as_input():
+    img_setup = isns._core._SetupImage(data)
+    f, ax, cax = img_setup.plot()
+
+    # check if data iput is what was plotted
+    np.testing.assert_array_equal(ax.images[0].get_array().data, data)
+
+    plt.close("all")
+
+
 @pytest.mark.parametrize(
-    "units", ["m", "um"]
-)  # units can't be None when dx is not None
-@pytest.mark.parametrize("dimension", [None, "si"])
-@pytest.mark.parametrize("cbar", [None, True, False])
-@pytest.mark.parametrize("orientation", ["h", "v"])
-@pytest.mark.parametrize("cbar_fontdict", [None, {"fontsize": 20}])
-@pytest.mark.parametrize("cbar_label", [None, "Cbar Label"])
-@pytest.mark.parametrize("cbar_ticks", [None, [0, 1, 2]])
-@pytest.mark.parametrize("showticks", [None, True, False])
-@pytest.mark.parametrize("despine", [None, True, False])
+    "cmap", [None, "acton"]
+)  # test if seaborn-image supplied cmaps are working
+@pytest.mark.parametrize(
+    "dx, units, dimension",
+    [(None, None, None), (1, "nm", "si"), (1, "1/um", "si-reciprocal")],
+)
+@pytest.mark.parametrize("cbar", [True, False])
+@pytest.mark.parametrize("orientation", ["horizontal", "h", "vertical", "v"])
+@pytest.mark.parametrize("showticks", [True, False])
+@pytest.mark.parametrize("despine", [True, False])
 def test_plot_w_all_inputs(
-    cmap,
-    vmin,
-    vmax,
-    title,
-    fontdict,
-    dx,
-    units,
-    dimension,
-    cbar,
-    orientation,
-    cbar_fontdict,
-    cbar_label,
-    cbar_ticks,
-    showticks,
-    despine,
+    cmap, cbar, dx, units, dimension, orientation, showticks, despine
 ):
     img_setup = isns._core._SetupImage(
         data,
         cmap=cmap,
-        vmin=vmin,
-        vmax=vmax,
-        title=title,
-        fontdict=fontdict,
+        vmin=None,
+        vmax=None,
+        title="My Title",
+        fontdict={"fontsize": 20},
         dx=dx,
         units=units,
         dimension=dimension,
         cbar=cbar,
         orientation=orientation,
-        cbar_fontdict=cbar_fontdict,
-        cbar_label=cbar_label,
-        cbar_ticks=cbar_ticks,
+        cbar_fontdict={"fontsize": 20},
+        cbar_label="cbar label",
+        cbar_ticks=[],
         showticks=showticks,
         despine=despine,
     )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -44,6 +44,12 @@ def test_setup_scalebar_dimension():
         img_setup._setup_scalebar(ax)
 
 
+def test_cbar_orientation():
+    with pytest.raises(ValueError):
+        img_setup = isns._core._SetupImage(data, cbar=True, orientation="right")
+        f, ax, cax = img_setup.plot()
+
+
 def test_plot_check_cbar_dict():
     with pytest.raises(TypeError):
         img_setup = isns._core._SetupImage(
@@ -63,10 +69,12 @@ def test_plot_check_cbar_dict():
 )  # units can't be None when dx is not None
 @pytest.mark.parametrize("dimension", [None, "si"])
 @pytest.mark.parametrize("cbar", [None, True, False])
+@pytest.mark.parametrize("orientation", ["h", "v"])
 @pytest.mark.parametrize("cbar_fontdict", [None, {"fontsize": 20}])
 @pytest.mark.parametrize("cbar_label", [None, "Cbar Label"])
 @pytest.mark.parametrize("cbar_ticks", [None, [0, 1, 2]])
 @pytest.mark.parametrize("showticks", [None, True, False])
+@pytest.mark.parametrize("despine", [None, True, False])
 def test_plot_w_all_inputs(
     cmap,
     vmin,
@@ -77,10 +85,12 @@ def test_plot_w_all_inputs(
     units,
     dimension,
     cbar,
+    orientation,
     cbar_fontdict,
     cbar_label,
     cbar_ticks,
     showticks,
+    despine,
 ):
     img_setup = isns._core._SetupImage(
         data,
@@ -93,10 +103,12 @@ def test_plot_w_all_inputs(
         units=units,
         dimension=dimension,
         cbar=cbar,
+        orientation=orientation,
         cbar_fontdict=cbar_fontdict,
         cbar_label=cbar_label,
         cbar_ticks=cbar_ticks,
         showticks=showticks,
+        despine=despine,
     )
     f, ax, cax = img_setup.plot()
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -6,6 +6,7 @@ import numpy as np
 import scipy.ndimage as ndi
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
+from skimage.filters import difference_of_gaussians
 
 import seaborn_image as isns
 
@@ -50,6 +51,45 @@ def test_filters(filter, fft, describe):
     assert isinstance(f, Figure)
     assert isinstance(ax, np.ndarray)
     assert isinstance(ax.ravel().all(), Axes)
-    assert filt_data.all() == data.all()
+
+    plt.close("all")
+
+
+def test_filterplot_gaussian():
+    f, ax, filt_data = isns.filterplot(data, filter="gaussian")
+
+    np.testing.assert_array_equal(filt_data, ndi.gaussian_filter(data, sigma=1))
+
+    plt.close("all")
+
+
+def test_filterplot_sobel():
+    f, ax, filt_data = isns.filterplot(data, filter="sobel")
+
+    np.testing.assert_array_equal(filt_data, ndi.sobel(data))
+
+    plt.close("all")
+
+
+def test_filterplot_median():
+    f, ax, filt_data = isns.filterplot(data, filter="median")
+
+    np.testing.assert_array_equal(filt_data, ndi.median_filter(data, size=5))
+
+    plt.close("all")
+
+
+def test_filterplot_max():
+    f, ax, filt_data = isns.filterplot(data, filter="max")
+
+    np.testing.assert_array_equal(filt_data, ndi.maximum_filter(data, size=5))
+
+    plt.close("all")
+
+
+def test_filterplot_diff_of_gaussian():
+    f, ax, filt_data = isns.filterplot(data, filter="diff_of_gaussians")
+
+    np.testing.assert_array_equal(filt_data, difference_of_gaussians(data, low_sigma=1))
 
     plt.close("all")

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -76,30 +76,19 @@ def test_imgplot_return():
     assert isinstance(ax, Axes)
     assert isinstance(cax, Axes)
 
+    plt.close("all")
 
-@pytest.mark.parametrize("cmap", [None, "acton", "inferno"])
-@pytest.mark.parametrize("cbar", [True, False])
-@pytest.mark.parametrize("cbar_label", ["My title", None])
-@pytest.mark.parametrize("cbar_fontdict", [{"fontsize": 20}, None])
-@pytest.mark.parametrize("showticks", [True, False])
-@pytest.mark.parametrize("title", ["My title", None])
-@pytest.mark.parametrize("title_fontdict", [{"fontsize": 20}, None])
+
+def test_imgplot_data_is_same_as_input():
+    f, ax, cax = isns.imgplot(data)
+
+    # check if data iput is what was plotted
+    np.testing.assert_array_equal(ax.images[0].get_array().data, data)
+
+
 @pytest.mark.parametrize("describe", [True, False])
-def test_imgplot_w_all_valid_inputs(
-    cmap, cbar, cbar_label, cbar_fontdict, showticks, title, title_fontdict, describe
-):
-    f, ax, cax = isns.imgplot(
-        data,
-        ax=None,
-        cmap=cmap,
-        describe=describe,
-        cbar=cbar,
-        cbar_label=cbar_label,
-        cbar_fontdict=cbar_fontdict,
-        showticks=showticks,
-        title=title,
-        title_fontdict=title_fontdict,
-    )
+def test_imgplot_w_all_valid_inputs(describe):
+    f, ax, cax = isns.imgplot(data, describe=describe)
     plt.close("all")
 
 
@@ -128,43 +117,31 @@ def test_imghist_return():
     assert isinstance(axes[1], Axes)
     assert isinstance(cax, Axes)
 
+    plt.close("all")
 
-@pytest.mark.parametrize("cmap", [None, "acton", "inferno"])
-@pytest.mark.parametrize("bins", [None, 500, 10])
-@pytest.mark.parametrize("cbar", [True, False])
-@pytest.mark.parametrize(
-    "orientation", ["h", "v"]
-)  # options can also be horizontal or vertical
-@pytest.mark.parametrize("cbar_label", ["My title", None])
-@pytest.mark.parametrize("cbar_fontdict", [{"fontsize": 20}, None])
+
+def test_imghist_data_is_same_as_input():
+    f, ax, cax = isns.imghist(data)
+
+    # check if data iput is what was plotted
+    np.testing.assert_array_equal(ax[0].images[0].get_array().data, data)
+
+
+@pytest.mark.parametrize("cmap", [None, "acton"])
+@pytest.mark.parametrize("bins", [None, 100])
+@pytest.mark.parametrize("orientation", ["horizontal", "h", "vertical", "v"])
 @pytest.mark.parametrize("showticks", [True, False])
-@pytest.mark.parametrize("title", ["My title", None])
-@pytest.mark.parametrize("title_fontdict", [{"fontsize": 20}, None])
-@pytest.mark.parametrize("describe", [True, False])
+@pytest.mark.parametrize("despine", [True, False])
 def test_imghist_w_all_valid_inputs(
-    cmap,
-    bins,
-    cbar,
-    orientation,
-    cbar_label,
-    cbar_fontdict,
-    showticks,
-    title,
-    title_fontdict,
-    describe,
+    cmap, bins, orientation, showticks, despine,
 ):
     f, axes, cax = isns.imghist(
         data,
         cmap=cmap,
         bins=bins,
-        describe=describe,
-        cbar=cbar,
         orientation=orientation,
-        cbar_label=cbar_label,
-        cbar_fontdict=cbar_fontdict,
         showticks=showticks,
-        title=title,
-        title_fontdict=title_fontdict,
+        despine=despine,
     )
 
     plt.close("all")

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -34,6 +34,11 @@ def test_cbar_type():
         isns.imgplot(data, cbar="True")
 
 
+def test_orientation_type():
+    with pytest.raises(TypeError):
+        isns.imgplot(data, orientation=1)
+
+
 def test_cbar_label_type():
     with pytest.raises(TypeError):
         isns.imgplot(data, cbar_label=["Title"])
@@ -47,6 +52,11 @@ def test_cbar_fontdict_type():
 def test_showticks_type():
     with pytest.raises(TypeError):
         isns.imgplot(data, showticks="True")
+
+
+def test_despine_type():
+    with pytest.raises(TypeError):
+        isns.imgplot(data, despine="True")
 
 
 def test_title_type():
@@ -105,6 +115,11 @@ def test_imghist_bins_value(bins):
         isns.imghist(data, bins=bins)
 
 
+def test_imghist_orientation_value():
+    with pytest.raises(ValueError):
+        isns.imghist(data, orientation="right")
+
+
 def test_imghist_return():
     f, axes, cax = isns.imghist(data)
 
@@ -117,6 +132,9 @@ def test_imghist_return():
 @pytest.mark.parametrize("cmap", [None, "acton", "inferno"])
 @pytest.mark.parametrize("bins", [None, 500, 10])
 @pytest.mark.parametrize("cbar", [True, False])
+@pytest.mark.parametrize(
+    "orientation", ["h", "v"]
+)  # options can also be horizontal or vertical
 @pytest.mark.parametrize("cbar_label", ["My title", None])
 @pytest.mark.parametrize("cbar_fontdict", [{"fontsize": 20}, None])
 @pytest.mark.parametrize("showticks", [True, False])
@@ -127,6 +145,7 @@ def test_imghist_w_all_valid_inputs(
     cmap,
     bins,
     cbar,
+    orientation,
     cbar_label,
     cbar_fontdict,
     showticks,
@@ -140,6 +159,7 @@ def test_imghist_w_all_valid_inputs(
         bins=bins,
         describe=describe,
         cbar=cbar,
+        orientation=orientation,
         cbar_label=cbar_label,
         cbar_fontdict=cbar_fontdict,
         showticks=showticks,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,42 @@
+import pytest
+
+import matplotlib
+import matplotlib.pyplot as plt
+
+import seaborn_image as isns
+
+matplotlib.use("AGG")  # use non-interactive backend for tests
+
+_all = ["top", "bottom", "right", "left"]
+
+
+@pytest.mark.parametrize(
+    "which", ["all", "top", "bottom", "right", "left", ["top", "right"], _all]
+)
+def test_despine(which):
+    f, ax = plt.subplots()
+
+    if which == "all":
+        which = _all
+
+    if isinstance(which, list):
+        for side in which:
+            isns.despine(which=side)
+            # assert ax.spines[side] == False
+    else:
+        isns.despine(which=which)
+        # assert ax.spines[which] == False
+
+    plt.close("all")
+
+
+def test_despine_value():
+    plt.subplots()
+    with pytest.raises(ValueError):
+        isns.despine(which="center")
+
+
+def test_despine_type():
+    plt.subplots()
+    with pytest.raises(TypeError):
+        isns.despine(which=0)


### PR DESCRIPTION
# This PR adds the following:
## Features
- orientation control for colorbar in `imgplot` and `imghist`
Example:
```python
isns.imgplot(data, orientaion="h") # this will plot the colorbar horizontal 
isns.imghist(data, orientation="h") # this will plot the colorbar and the histogram horizontal
# other options include: "v", "vertical", "horizontal"
```
- despine plots by default; available as a parameter in `imgplot` and `imghist`
- `isns.despine()` also available independently
-  `isns.scientific_ticks()` : make colorbar ticks scientific

## Tests
- Remove unnecessary parametrization to exponentially speed up the test suite; without significantly hurting the test coverage