### PR TITLE
`filterplot`, and by extension `FilterGrid`, now accepts any callable filter

### DIFF
--- a/src/seaborn_image/_filters.py
+++ b/src/seaborn_image/_filters.py
@@ -58,11 +58,9 @@ def filterplot(
     Args:
         data: Image data (array-like). Supported array shapes are all
             `matplotlib.pyplot.imshow` array shapes
-        filt (str, optional): Image filter to be used for processing.
-            Defaults to "gaussian".
-            Options include: "sobel", "gaussian", "median", "max", "diff_of_gaussians",
-            "gaussian_gradient_magnitude", "gaussian_laplace", "laplace", "min", "percentile",
-            "prewitt", "rank", "uniform".
+        filt (str or callable, optional): Filter name or function to be applied.
+            Filter name can be a string from `seaborn_image.implemented_filters` or a callable
+            filter. Defaults to "gaussian".
         cmap (str or `matplotlib.colors.Colormap`, optional): Colormap for image.
             Can be a seaborn-image colormap or default matplotlib colormaps or
             any other colormap converted to a matplotlib colormap. Defaults to None.
@@ -103,21 +101,32 @@ def filterplot(
             For instance, "sigma" or "size" or "mode" etc.
 
     Raises:
-        TypeError: if `filt` is not a string type
+        TypeError: if `filt` is not a string type or callable function
         NotImplementedError: if a `filt` that is not implemented is specified
+        TypeError: if `describe` is not a `bool`
 
     Returns:
         (tuple): tuple containing:
 
-            (`matplotlib.figure.Figure`): Matplotlib figure.
             (`matplotlib.axes.Axes`): Matplotlib axes where the image is drawn.
+            (`matplotlib.axes.Axes`): Colorbar axes
             (`numpy.array`): Filtered image data
 
     Example:
         >>> import seaborn_image as isns
-        >>> isns.filterplot(data) # use default gaussian filt
-        >>> isns.filterplot(data, "percentile", percentile=35) # specify a filt with specific parameter
-        >>> isns.filterplot(data, dx=3, units="um") # specify scalebar for the filterplot
+
+        >>> # use default gaussian filter
+        >>> isns.filterplot(data, sigma=3)
+
+        >>> # specify a filt with specific parameter
+        >>> isns.filterplot(data, "percentile", percentile=35, size=10)
+
+        >>> # callable filter
+        >>> import scipy.ndimage as ndi
+        >>> isns.filterplot(data, ndi.gaussian_filter, sigma=3)
+
+        >>> # specify scalebar for the filterplot
+        >>> isns.filterplot(data, "sobel", dx=3, units="um")
     """
 
     if not isinstance(describe, bool):

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -23,8 +23,7 @@ class FilterGrid(object):
     Args:
         data : Image data (array-like). Supported array shapes are all
             `matplotlib.pyplot.imshow` array shapes
-        filt (str, optional): Name of the filter to be applied.
-            Defaults to "gaussian".
+        filt (str or callable): Filter name or function to be applied.
         row (str, optional): Parameter name that is to be displayed
             along the row. Defaults to None.
         col (str, optional): Parameter name that is to be displayed
@@ -103,7 +102,7 @@ class FilterGrid(object):
     def __init__(
         self,
         data,
-        filt="gaussian",
+        filt,
         *,
         row=None,
         col=None,
@@ -126,6 +125,9 @@ class FilterGrid(object):
 
         if data is None:
             raise ValueError("image data can not be None")
+
+        if filt is None:
+            raise ValueError("'filt' can not be None; must be a string or callable")
 
         row_params = []
         if row is not None:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -22,7 +22,7 @@ def test_filter_not_implemented():
         isns.filterplot(data, filt="not-implemented-filt")
 
 
-@pytest.mark.parametrize("filt", [["gaussian"], ndi.gaussian_filter, None])
+@pytest.mark.parametrize("filt", [["gaussian"], None])
 def test_filter_types(filt):
     with pytest.raises(TypeError):
         isns.filterplot(data, filt=filt)
@@ -31,13 +31,13 @@ def test_filter_types(filt):
 @pytest.mark.parametrize("describe", ["True", "False", None, 1])
 def test_describe_type(describe):
     with pytest.raises(TypeError):
-        isns.imgplot(data, describe=describe)
+        isns.filterplot(data, "sobel", describe=describe)
 
 
-@pytest.mark.parametrize("filt", isns.implemented_filters)
+# @pytest.mark.parametrize("filt", isns.implemented_filters)
 @pytest.mark.parametrize("describe", [True, False])
-def test_filters(filt, describe):
-    ax, cax, filt_data = isns.filterplot(data, filt=filt, describe=describe)
+def test_filters(describe):
+    ax, cax, filt_data = isns.filterplot(data, "sobel", describe=describe)
 
     assert isinstance(ax, Axes)
     assert isinstance(cax, Axes)
@@ -45,8 +45,19 @@ def test_filters(filt, describe):
     plt.close("all")
 
 
+def test_filterplot_callable_filt():
+    "Test a callable filt parameter with additional parameters passed to the callable filt function"
+    _, _, filt_data = isns.filterplot(data, ndi.uniform_filter, size=5, mode="nearest")
+
+    np.testing.assert_array_equal(
+        filt_data, ndi.uniform_filter(data, size=5, mode="nearest")
+    )
+
+    plt.close("all")
+
+
 def test_filterplot_gaussian():
-    _, _, filt_data = isns.filterplot(data, filt="gaussian")
+    _, _, filt_data = isns.filterplot(data, filt="gaussian", sigma=1)
 
     np.testing.assert_array_equal(filt_data, ndi.gaussian_filter(data, sigma=1))
 
@@ -62,7 +73,7 @@ def test_filterplot_sobel():
 
 
 def test_filterplot_median():
-    _, _, filt_data = isns.filterplot(data, filt="median")
+    _, _, filt_data = isns.filterplot(data, filt="median", size=5)
 
     np.testing.assert_array_equal(filt_data, ndi.median_filter(data, size=5))
 
@@ -70,7 +81,7 @@ def test_filterplot_median():
 
 
 def test_filterplot_max():
-    _, _, filt_data = isns.filterplot(data, filt="max")
+    _, _, filt_data = isns.filterplot(data, filt="max", size=5)
 
     np.testing.assert_array_equal(filt_data, ndi.maximum_filter(data, size=5))
 
@@ -78,7 +89,7 @@ def test_filterplot_max():
 
 
 def test_filterplot_diff_of_gaussian():
-    _, _, filt_data = isns.filterplot(data, filt="diff_of_gaussians")
+    _, _, filt_data = isns.filterplot(data, filt="diff_of_gaussians", low_sigma=1)
 
     np.testing.assert_array_equal(filt_data, difference_of_gaussians(data, low_sigma=1))
 
@@ -86,7 +97,7 @@ def test_filterplot_diff_of_gaussian():
 
 
 def test_filterplot_gaussian_gradient_magnitude():
-    _, _, filt_data = isns.filterplot(data, filt="gaussian_gradient_magnitude")
+    _, _, filt_data = isns.filterplot(data, filt="gaussian_gradient_magnitude", sigma=1)
 
     np.testing.assert_array_equal(
         filt_data, ndi.gaussian_gradient_magnitude(data, sigma=1)
@@ -96,7 +107,7 @@ def test_filterplot_gaussian_gradient_magnitude():
 
 
 def test_filterplot_gaussian_laplace():
-    _, _, filt_data = isns.filterplot(data, filt="gaussian_laplace")
+    _, _, filt_data = isns.filterplot(data, filt="gaussian_laplace", sigma=1)
 
     np.testing.assert_array_equal(filt_data, ndi.gaussian_laplace(data, sigma=1))
 
@@ -112,7 +123,7 @@ def test_filterplot_laplace():
 
 
 def test_filterplot_min():
-    _, _, filt_data = isns.filterplot(data, filt="min")
+    _, _, filt_data = isns.filterplot(data, filt="min", size=5)
 
     np.testing.assert_array_equal(filt_data, ndi.minimum_filter(data, size=5))
 
@@ -120,7 +131,7 @@ def test_filterplot_min():
 
 
 def test_filterplot_percentile():
-    _, _, filt_data = isns.filterplot(data, filt="percentile")
+    _, _, filt_data = isns.filterplot(data, filt="percentile", percentile=10, size=10)
 
     np.testing.assert_array_equal(
         filt_data, ndi.percentile_filter(data, percentile=10, size=10)
@@ -138,7 +149,7 @@ def test_filterplot_prewitt():
 
 
 def test_filterplot_rank():
-    _, _, filt_data = isns.filterplot(data, filt="rank")
+    _, _, filt_data = isns.filterplot(data, filt="rank", rank=1, size=10)
 
     np.testing.assert_array_equal(filt_data, ndi.rank_filter(data, rank=1, size=10))
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -17,30 +17,35 @@ class TestFilterGrid(object):
 
     def test_none_data(self):
         with pytest.raises(ValueError):
-            isns.FilterGrid(None)
+            isns.FilterGrid(None, "sobel")
+
+    def test_none_filt(self):
+        with pytest.raises(ValueError):
+            isns.FilterGrid(self.data, None)
 
     def test_self_data(self):
-        g = isns.FilterGrid(self.data)
+        g = isns.FilterGrid(self.data, "sobel")
         np.testing.assert_array_equal(self.data, g.data)
         plt.close()
 
     def test_self_fig(self):
-        g = isns.FilterGrid(self.data)
+        g = isns.FilterGrid(self.data, "sobel")
         assert isinstance(g.fig, Figure)
         plt.close()
 
     def test_self_axes(self):
 
-        g0 = isns.FilterGrid(self.data)
+        g0 = isns.FilterGrid(self.data, "sobel")
         for ax in g0.axes.flat:
             assert isinstance(ax, Axes)
 
-        g1 = isns.FilterGrid(self.data, row="sigma", sigma=[1, 2, 3])
+        g1 = isns.FilterGrid(self.data, "gaussian", row="sigma", sigma=[1, 2, 3])
         for ax in g1.axes.flat:
             assert isinstance(ax, Axes)
 
         g2 = isns.FilterGrid(
             self.data,
+            "gaussian",
             row="mode",
             col="sigma",
             sigma=[1, 2, 3],
@@ -53,17 +58,18 @@ class TestFilterGrid(object):
 
     def test_axes_shape(self):
 
-        g0 = isns.FilterGrid(self.data)
+        g0 = isns.FilterGrid(self.data, "sobel")
         assert g0.axes.shape == (1, 1)
 
-        g1 = isns.FilterGrid(self.data, row="sigma", sigma=[1, 2, 3])
+        g1 = isns.FilterGrid(self.data, "gaussian", row="sigma", sigma=[1, 2, 3])
         assert g1.axes.shape == (3, 1)
 
-        g2 = isns.FilterGrid(self.data, col="sigma", sigma=[1, 2, 3])
+        g2 = isns.FilterGrid(self.data, "gaussian", col="sigma", sigma=[1, 2, 3])
         assert g2.axes.shape == (1, 3)
 
         g3 = isns.FilterGrid(
             self.data,
+            "gaussian",
             row="sigma",
             col="mode",
             sigma=[1, 2, 3],
@@ -73,6 +79,7 @@ class TestFilterGrid(object):
 
         g4 = isns.FilterGrid(
             self.data,
+            "gaussian",
             row="mode",
             col="sigma",
             sigma=[1, 2, 3],
@@ -87,16 +94,21 @@ class TestFilterGrid(object):
 
     def test_col_wrap(self):
 
-        g0 = isns.FilterGrid(self.data, col="sigma", sigma=[1, 2, 3, 4, 5], col_wrap=3)
+        g0 = isns.FilterGrid(
+            self.data, "gaussian", col="sigma", sigma=[1, 2, 3, 4, 5], col_wrap=3
+        )
         assert g0.axes.shape == (2, 3)
         plt.close()
 
         with pytest.raises(ValueError):
-            isns.FilterGrid(self.data, row="sigma", sigma=[1, 2, 3, 4, 5], col_wrap=3)
+            isns.FilterGrid(
+                self.data, "gaussian", row="sigma", sigma=[1, 2, 3, 4, 5], col_wrap=3
+            )
 
         with pytest.raises(ValueError):
             isns.FilterGrid(
                 self.data,
+                "gaussian",
                 row="mode",
                 col="sigma",
                 col_wrap=3,
@@ -106,14 +118,19 @@ class TestFilterGrid(object):
 
     def test_additional_kwargs_for_filters(self):
 
-        isns.FilterGrid(self.data, row="sigma", sigma=[1, 2, 3], mode="reflect")
+        isns.FilterGrid(
+            self.data, "gaussian", row="sigma", sigma=[1, 2, 3], mode="reflect"
+        )
         plt.close()
 
-        isns.FilterGrid(self.data, col="sigma", sigma=[1, 2, 3], mode="reflect")
+        isns.FilterGrid(
+            self.data, "gaussian", col="sigma", sigma=[1, 2, 3], mode="reflect"
+        )
         plt.close()
 
         isns.FilterGrid(
             self.data,
+            "gaussian",
             row="sigma",
             col="mode",
             sigma=[1, 2, 3],
@@ -124,14 +141,15 @@ class TestFilterGrid(object):
 
     def test_figure_size(self):
 
-        g0 = isns.FilterGrid(self.data)
+        g0 = isns.FilterGrid(self.data, "sobel")
         np.testing.assert_array_equal(g0.fig.get_size_inches(), (3, 3))
 
-        g1 = isns.FilterGrid(self.data, row="sigma", sigma=[1, 2, 3])
+        g1 = isns.FilterGrid(self.data, "gaussian", row="sigma", sigma=[1, 2, 3])
         np.testing.assert_array_equal(g1.fig.get_size_inches(), (3, 9))
 
         g2 = isns.FilterGrid(
             self.data,
+            "gaussian",
             row="sigma",
             col="mode",
             sigma=[1, 2, 3],
@@ -141,6 +159,7 @@ class TestFilterGrid(object):
 
         g3 = isns.FilterGrid(
             self.data,
+            "gaussian",
             row="sigma",
             col="mode",
             sigma=[1, 2, 3],
@@ -151,6 +170,7 @@ class TestFilterGrid(object):
 
         g4 = isns.FilterGrid(
             self.data,
+            "gaussian",
             row="sigma",
             col="mode",
             sigma=[1, 2, 3],


### PR DESCRIPTION
The following is now accepted : 
```python
>>> import seaborn_image as isns
>>> import scipy.ndimage as ndi
>>> isns.filterplot(data, ndi.gaussian_filter, sigma=5)
>>> isns.FilterGrid(data, ndi.gaussian_filter, row="sigma", sigma=[3,4,5,6])
```
Note: the `filt` parameter can be any callable filter. It also accepts `str` but only for the ones mapped in seaborn-image. You can do `isns.implemented_filters` to get the mapped filters that can be used as strings.