### PR TITLE
Exclude outliers using `robust` parameter while plotting

### DIFF
--- a/src/seaborn_image/_core.py
+++ b/src/seaborn_image/_core.py
@@ -30,7 +30,7 @@ class _SetupImage(object):
         vmin=None,
         vmax=None,
         robust=False,
-        percentile=None,
+        perc=None,
         title=None,
         fontdict=None,
         dx=None,
@@ -51,7 +51,7 @@ class _SetupImage(object):
         self.vmin = vmin
         self.vmax = vmax
         self.robust = robust
-        self.percentile = percentile
+        self.perc = perc
         self.title = title
         self.fontdict = fontdict
         self.dx = dx
@@ -117,12 +117,12 @@ class _SetupImage(object):
                 min_robust = (
                     True  # remember that vmin was None and now set to new value
                 )
-                self.vmin = np.nanpercentile(self.data, self.percentile[0])
+                self.vmin = np.nanpercentile(self.data, self.perc[0])
             if self.vmax is None:
                 max_robust = (
                     True  # remember that vmax was None and now set to new value
                 )
-                self.vmax = np.nanpercentile(self.data, self.percentile[1])
+                self.vmax = np.nanpercentile(self.data, self.perc[1])
 
         # TODO move everything other than data to kwargs
         _map = ax.imshow(self.data, cmap=self.cmap, vmin=self.vmin, vmax=self.vmax)

--- a/src/seaborn_image/_core.py
+++ b/src/seaborn_image/_core.py
@@ -29,6 +29,8 @@ class _SetupImage(object):
         cmap=None,
         vmin=None,
         vmax=None,
+        robust=False,
+        percentile=None,
         title=None,
         fontdict=None,
         dx=None,
@@ -48,6 +50,8 @@ class _SetupImage(object):
         self.cmap = cmap
         self.vmin = vmin
         self.vmax = vmax
+        self.robust = robust
+        self.percentile = percentile
         self.title = title
         self.fontdict = fontdict
         self.dx = dx
@@ -108,6 +112,18 @@ class _SetupImage(object):
         if self.cmap in _CMAP_QUAL.keys():
             self.cmap = _CMAP_QUAL.get(self.cmap).mpl_colormap
 
+        if self.robust:
+            if self.vmin is None:
+                min_robust = (
+                    True  # remember that vmin was None and now set to new value
+                )
+                self.vmin = np.nanpercentile(self.data, self.percentile[0])
+            if self.vmax is None:
+                max_robust = (
+                    True  # remember that vmax was None and now set to new value
+                )
+                self.vmax = np.nanpercentile(self.data, self.percentile[1])
+
         # TODO move everything other than data to kwargs
         _map = ax.imshow(self.data, cmap=self.cmap, vmin=self.vmin, vmax=self.vmax)
 
@@ -134,7 +150,22 @@ class _SetupImage(object):
                     "'orientation' must be either : 'horizontal' or 'h' / 'vertical' or 'v'"
                 )
 
-            cb = f.colorbar(_map, cax=cax, orientation=self.orientation)
+            # extend specific colorbar regions if robust is True
+            if self.robust:
+                if min_robust and max_robust:
+                    cb = f.colorbar(
+                        _map, cax=cax, orientation=self.orientation, extend="both"
+                    )
+                elif min_robust:
+                    cb = f.colorbar(
+                        _map, cax=cax, orientation=self.orientation, extend="min"
+                    )
+                elif max_robust:
+                    cb = f.colorbar(
+                        _map, cax=cax, orientation=self.orientation, extend="max"
+                    )
+            else:
+                cb = f.colorbar(_map, cax=cax, orientation=self.orientation)
 
             if self.despine:
                 cb.outline.set_visible(False)  # remove colorbar outline border

--- a/src/seaborn_image/_filters.py
+++ b/src/seaborn_image/_filters.py
@@ -36,6 +36,8 @@ def filterplot(
     cmap=None,
     vmin=None,
     vmax=None,
+    robust=False,
+    perc=(2, 98),
     dx=None,
     units=None,
     dimension=None,
@@ -66,6 +68,11 @@ def filterplot(
             any other colormap converted to a matplotlib colormap. Defaults to None.
         vmin (float, optional): Minimum data value that colormap covers. Defaults to None.
         vmax (float, optional): Maximum data value that colormap covers. Defaults to None.
+        robust (bool, optional): If True and vmin or vmax are None, colormap range is calculated
+            based on the percentiles defined in `percentile` parameter. Defaults to False.
+        perc (tuple or list, optional): If `robust` is True, colormap range is calculated based
+            on the percentiles specified instead of the extremes. Defaults to (2,98) - 2nd and 98th
+            percentiles for min and max values.
         dx (float, optional): Size per pixel of the image data. If scalebar
             is required, `dx` and `units` must be sepcified. Defaults to None.
         units (str, optional): Units of `dx`. Defaults to None.
@@ -160,6 +167,8 @@ def filterplot(
         cmap=cmap,
         vmin=vmin,
         vmax=vmax,
+        robust=robust,
+        perc=perc,
         dx=dx,
         units=units,
         dimension=dimension,

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -38,7 +38,7 @@ def imgplot(
 ):
     """
 
-    Plot data as a 2-D image with options to add scalebar, colorbar, title.
+    Plot data as a 2-D image with options to ignore outliers, add scalebar, colorbar, title.
 
     Args:
         data: Image data (array-like). Supported array shapes are all

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -21,7 +21,7 @@ def imgplot(
     vmin=None,
     vmax=None,
     robust=False,
-    percentile=(2, 98),
+    perc=(2, 98),
     dx=None,
     units=None,
     dimension=None,
@@ -54,7 +54,7 @@ def imgplot(
         vmax (float, optional): Maximum data value that colormap covers. Defaults to None.
         robust (bool, optional): If True and vmin or vmax are None, colormap range is calculated
             based on the percentiles defined in `percentile` parameter. Defaults to False.
-        percentile (tuple or list, optional): If `robust` is True, colormap range is calculated based
+        perc (tuple or list, optional): If `robust` is True, colormap range is calculated based
             on the percentiles specified instead of the extremes. Defaults to (2,98) - 2nd and 98th
             percentiles for min and max values.
         dx (float, optional): Size per pixel of the image data. If scalebar
@@ -102,8 +102,8 @@ def imgplot(
         TypeError: if `despine` is not bool
         TypeError: if `title` is not str
         TypeError: if `title_fontdict` is not dict
-        AssertionError: if `len(percentile)` is not equal to 2
-        AssertionError: if the first element of percentile is greater than the second
+        AssertionError: if `len(perc)` is not equal to 2
+        AssertionError: if the first element of `perc` is greater than the second
 
     Returns:
         (tuple): tuple containing:
@@ -152,8 +152,8 @@ def imgplot(
         raise TypeError("'robust' must be either True or False")
 
     if robust is True:
-        assert len(percentile) == 2
-        assert percentile[0] < percentile[1]  # order should be (min, max)
+        assert len(perc) == 2
+        assert perc[0] < perc[1]  # order should be (min, max)
 
     if not isinstance(cbar, bool):
         raise TypeError
@@ -200,7 +200,7 @@ def imgplot(
         vmin=vmin,
         vmax=vmax,
         robust=robust,
-        percentile=percentile,
+        perc=perc,
         dx=dx,
         units=units,
         dimension=dimension,
@@ -235,6 +235,8 @@ def imghist(
     bins=None,
     vmin=None,
     vmax=None,
+    robust=False,
+    perc=(2, 98),
     dx=None,
     units=None,
     dimension=None,
@@ -262,6 +264,11 @@ def imghist(
             is used.
         vmin (float, optional): Minimum data value that colormap covers. Defaults to None.
         vmax (float, optional): Maximum data value that colormap covers. Defaults to None.
+        robust (bool, optional): If True and vmin or vmax are None, colormap range is calculated
+            based on the percentiles defined in `percentile` parameter. Defaults to False.
+        perc (tuple or list, optional): If `robust` is True, colormap range is calculated based
+            on the percentiles specified instead of the extremes. Defaults to (2,98) - 2nd and 98th
+            percentiles for min and max values.
         dx (float, optional): Size per pixel of the image data. If scalebar
             is required, `dx` and `units` must be sepcified. Defaults to None.
         units (str, optional): Units of `dx`. Defaults to None.
@@ -344,6 +351,8 @@ def imghist(
         cmap=cmap,
         vmin=vmin,
         vmax=vmax,
+        robust=robust,
+        perc=perc,
         dx=dx,
         units=units,
         dimension=dimension,

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -20,6 +20,8 @@ def imgplot(
     gray=None,
     vmin=None,
     vmax=None,
+    robust=False,
+    percentile=(2, 98),
     dx=None,
     units=None,
     dimension=None,
@@ -50,6 +52,11 @@ def imgplot(
             If True and cmap is None, cmap will be set to "gray".
         vmin (float, optional): Minimum data value that colormap covers. Defaults to None.
         vmax (float, optional): Maximum data value that colormap covers. Defaults to None.
+        robust (bool, optional): If True and vmin or vmax are None, colormap range is calculated
+            based on the percentiles defined in `percentile` parameter. Defaults to False.
+        percentile (tuple or list, optional): If `robust` is True, colormap range is calculated based
+            on the percentiles specified instead of the extremes. Defaults to (2,98) - 2nd and 98th
+            percentiles for min and max values.
         dx (float, optional): Size per pixel of the image data. If scalebar
             is required, `dx` and `units` must be sepcified. Defaults to None.
         units (str, optional): Units of `dx`. Defaults to None.
@@ -85,6 +92,8 @@ def imgplot(
     Raises:
         TypeError: if `cmap` is not str or `matplotlib.colors.Colormap`
         TypeError: if `ax` is not `matplotlib.axes.Axes`
+        TypeError: if `describe` is not bool
+        TypeError: if `robust` is not bool
         TypeError: if `cbar` is not bool
         TypeError: if `orientation` is not str
         TypeError: if `cbar_label` is not str
@@ -93,6 +102,8 @@ def imgplot(
         TypeError: if `despine` is not bool
         TypeError: if `title` is not str
         TypeError: if `title_fontdict` is not dict
+        AssertionError: if `len(percentile)` is not equal to 2
+        AssertionError: if the first element of percentile is greater than the second
 
     Returns:
         (tuple): tuple containing:
@@ -102,14 +113,30 @@ def imgplot(
 
     Example:
         >>> import seaborn_image as isns
+
         >>> isns.imgplot(data)
-        >>> isns.imgplot(data, dx=2, units="nm") # add a scalebar
-        >>> isns.imgplot(data, cmap="deep") # specify a colormap
 
+        >>> # add a scalebar
+        >>> isns.imgplot(data, dx=2, units="nm")
 
+        >>> # specify a colormap
+        >>> isns.imgplot(data, cmap="deep")
+
+        >>> # convert RGB image to grayscale
+        >>> isns.imgplot(data, gray=True)
+
+        >>> # exclude the outliers
+        >>> isns.imgplot(data, robust=True)
+
+        >>> # change colorbar orientation
+        >>> isns.imgplot(data, orientation="h") # horizontal
+        >>> isns.imgplot(data, orientation="v") # vertical
+
+        >>> # add a colorbar label
+        >>> isns.imgplot(data, cbar_label="Label (au)")
     """
 
-    # add vmin, vmax, dx, units to checks
+    # TODO add vmin, vmax, dx, units to checks
     if cmap is not None:
         if not isinstance(cmap, (str, Colormap)):
             raise TypeError
@@ -120,6 +147,13 @@ def imgplot(
 
     if not isinstance(describe, bool):
         raise TypeError
+
+    if not isinstance(robust, bool):
+        raise TypeError("'robust' must be either True or False")
+
+    if robust is True:
+        assert len(percentile) == 2
+        assert percentile[0] < percentile[1]  # order should be (min, max)
 
     if not isinstance(cbar, bool):
         raise TypeError
@@ -152,6 +186,7 @@ def imgplot(
     if isinstance(data, np.ndarray):
         if data.ndim == 3:
             cbar = False  # set cbar to False if RGB image
+            robust = False  # set robust to False if RGB image
             if gray is True:  # if gray is True, convert to grayscale
                 data = rgb2gray(data)
 
@@ -164,6 +199,8 @@ def imgplot(
         cmap=cmap,
         vmin=vmin,
         vmax=vmax,
+        robust=robust,
+        percentile=percentile,
         dx=dx,
         units=units,
         dimension=dimension,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -59,26 +59,26 @@ def test_plot_check_cbar_dict():
 
 
 def test_robust_param():
-    img_setup = isns._core._SetupImage(data, robust=True, percentile=(2, 98))
+    img_setup = isns._core._SetupImage(data, robust=True, perc=(2, 98))
     f, ax, cax = img_setup.plot()
     assert img_setup.vmin == np.nanpercentile(data, 2)
     assert img_setup.vmax == np.nanpercentile(data, 98)
     plt.close()
 
-    img_setup = isns._core._SetupImage(data, robust=True, percentile=(2, 98), vmin=0)
+    img_setup = isns._core._SetupImage(data, robust=True, perc=(2, 98), vmin=0)
     f, ax, cax = img_setup.plot()
     assert img_setup.vmin == 0
     assert img_setup.vmax == np.nanpercentile(data, 98)
     plt.close()
 
-    img_setup = isns._core._SetupImage(data, robust=True, percentile=(2, 98), vmax=1)
+    img_setup = isns._core._SetupImage(data, robust=True, perc=(2, 98), vmax=1)
     f, ax, cax = img_setup.plot()
     assert img_setup.vmin == np.nanpercentile(data, 2)
     assert img_setup.vmax == 1
     plt.close()
 
     img_setup = isns._core._SetupImage(
-        data, robust=True, percentile=(2, 98), vmin=0, vmax=1
+        data, robust=True, perc=(2, 98), vmin=0, vmax=1
     )
     f, ax, cax = img_setup.plot()
     assert img_setup.vmin == 0
@@ -128,7 +128,7 @@ def test_plot_w_all_inputs(
         vmin=None,
         vmax=None,
         robust=robust,
-        percentile=(2, 98),
+        perc=(2, 98),
         title="My Title",
         fontdict={"fontsize": 20},
         dx=dx,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -58,13 +58,40 @@ def test_plot_check_cbar_dict():
         f, ax, cax = img_setup.plot()
 
 
+def test_robust_param():
+    img_setup = isns._core._SetupImage(data, robust=True, percentile=(2, 98))
+    f, ax, cax = img_setup.plot()
+    assert img_setup.vmin == np.nanpercentile(data, 2)
+    assert img_setup.vmax == np.nanpercentile(data, 98)
+    plt.close()
+
+    img_setup = isns._core._SetupImage(data, robust=True, percentile=(2, 98), vmin=0)
+    f, ax, cax = img_setup.plot()
+    assert img_setup.vmin == 0
+    assert img_setup.vmax == np.nanpercentile(data, 98)
+    plt.close()
+
+    img_setup = isns._core._SetupImage(data, robust=True, percentile=(2, 98), vmax=1)
+    f, ax, cax = img_setup.plot()
+    assert img_setup.vmin == np.nanpercentile(data, 2)
+    assert img_setup.vmax == 1
+    plt.close()
+
+    img_setup = isns._core._SetupImage(
+        data, robust=True, percentile=(2, 98), vmin=0, vmax=1
+    )
+    f, ax, cax = img_setup.plot()
+    assert img_setup.vmin == 0
+    assert img_setup.vmax == 1
+    plt.close()
+
+
 def test_data_plotted_is_same_as_input():
     img_setup = isns._core._SetupImage(data)
     f, ax, cax = img_setup.plot()
 
     # check if data iput is what was plotted
     np.testing.assert_array_equal(ax.images[0].get_array().data, data)
-
     plt.close("all")
 
 
@@ -79,14 +106,17 @@ def test_data_plotted_is_same_as_input():
 @pytest.mark.parametrize("orientation", ["horizontal", "h", "vertical", "v"])
 @pytest.mark.parametrize("showticks", [True, False])
 @pytest.mark.parametrize("despine", [True, False])
+@pytest.mark.parametrize("robust", [True, False])
 def test_plot_w_all_inputs(
-    cmap, cbar, dx, units, dimension, orientation, showticks, despine
+    cmap, cbar, dx, units, dimension, orientation, showticks, despine, robust
 ):
     img_setup = isns._core._SetupImage(
         data,
         cmap=cmap,
         vmin=None,
         vmax=None,
+        robust=robust,
+        percentile=(2, 98),
         title="My Title",
         fontdict={"fontsize": 20},
         dx=dx,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -106,9 +106,21 @@ def test_data_plotted_is_same_as_input():
 @pytest.mark.parametrize("orientation", ["horizontal", "h", "vertical", "v"])
 @pytest.mark.parametrize("showticks", [True, False])
 @pytest.mark.parametrize("despine", [True, False])
+@pytest.mark.parametrize("vmin", [None, 0])
+@pytest.mark.parametrize("vmax", [None, 1])
 @pytest.mark.parametrize("robust", [True, False])
 def test_plot_w_all_inputs(
-    cmap, cbar, dx, units, dimension, orientation, showticks, despine, robust
+    cmap,
+    vmin,
+    vmax,
+    cbar,
+    dx,
+    units,
+    dimension,
+    orientation,
+    showticks,
+    despine,
+    robust,
 ):
     img_setup = isns._core._SetupImage(
         data,

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -31,6 +31,17 @@ def test_describe_type():
         isns.imgplot(data, describe=["True"])
 
 
+def test_robust_type():
+    with pytest.raises(TypeError):
+        isns.imgplot(data, robust="True")
+
+
+@pytest.mark.parametrize("percentile", [(2, 10, 88), (45, 40)])
+def test_percentile(percentile):
+    with pytest.raises(AssertionError):
+        isns.imgplot(data, robust=True, percentile=percentile)
+
+
 def test_cbar_type():
     with pytest.raises(TypeError):
         isns.imgplot(data, cbar="True")

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -36,10 +36,10 @@ def test_robust_type():
         isns.imgplot(data, robust="True")
 
 
-@pytest.mark.parametrize("percentile", [(2, 10, 88), (45, 40)])
-def test_percentile(percentile):
+@pytest.mark.parametrize("perc", [(2, 10, 88), (45, 40)])
+def test_percentile(perc):
     with pytest.raises(AssertionError):
-        isns.imgplot(data, robust=True, percentile=percentile)
+        isns.imgplot(data, robust=True, perc=perc)
 
 
 def test_cbar_type():


### PR DESCRIPTION
Colormap range is calculated based on the percentiles defined in `perc` percentile parameter instead of the extremes when `robust` is `True`. Default `perc` range is (2,98) - 2nd and 98th percentiles for min and max values.

`robust` had been added to `imgplot`, `imghist`, `filterplot`
Example Usage:
```python
"""Exclude outliers"""
>>> isns.imgplot(data, robust=True)

"""Specify percentiles for min and max values"""
>>> isns.imgplot(data, robust=True, perc=(2, 99))
```