### PR TITLE
fix `robust` state issue when `vmin`, `vmax` specified

### DIFF
--- a/src/seaborn_image/_core.py
+++ b/src/seaborn_image/_core.py
@@ -113,6 +113,8 @@ class _SetupImage(object):
             self.cmap = _CMAP_QUAL.get(self.cmap).mpl_colormap
 
         if self.robust:
+            min_robust = False
+            max_robust = False
             if self.vmin is None:
                 min_robust = (
                     True  # remember that vmin was None and now set to new value


### PR DESCRIPTION
This PR fixes a minor bug that came about when `vmin`/`vmax` was specified with `robust` parameter in `imgplot()`