### PR TITLE
Clean up imgplot kwargs, reformat docstrings to numpy style & use matplotlib plot-directive in docstring examples

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,6 +11,6 @@ jobs:
         architecture: x64
     - run: pip install nox==2020.5.24
     - run: pip install poetry==1.0.9
-    - run: nox --sessions tests coverage
+    - run: nox --sessions tests coverage xdoctest
       env:
         CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,8 +5,19 @@ import sphinx_bootstrap_theme
 project = "seaborn-image"
 author = "Sarthak Jariwala"
 copyright = f"{datetime.now().year}, {author}"
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon", "sphinxcontrib.images"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinxcontrib.images",
+    "matplotlib.sphinxext.plot_directive",
+]
 html_static_path = ["_static"]
+
+
+plot_include_source = True
+plot_formats = [("png", 90)]
+plot_html_show_formats = False
+plot_html_show_source_link = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -44,3 +44,12 @@ seaborn_image._context
    :members:
    :undoc-members:
    :show-inheritance:
+
+
+seaborn_image.utils
+-------------------
+
+.. automodule:: seaborn_image.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import nox
 
 locations = "src", "tests", "noxfile.py", "docs/conf.py"
-nox.options.sessions = "safety", "tests"
+nox.options.sessions = "safety", "tests", "xdoctest"
 
 
 def install_with_constraints(session, *args, **kwargs):
@@ -38,6 +38,15 @@ def coverage(session):
     install_with_constraints(session, "coverage[toml]", "codecov")
     session.run("coverage", "xml", "--fail-under=0")
     session.run("codecov", *session.posargs)
+
+
+@nox.session()
+def xdoctest(session):
+    """Run examples with xdoctest."""
+    args = session.posargs or ["all"]
+    session.run("poetry", "install", "--no-dev", external=True)
+    install_with_constraints(session, "xdoctest")
+    session.run("python", "-m", "xdoctest", "seaborn_image", *args)
 
 
 @nox.session()

--- a/poetry.lock
+++ b/poetry.lock
@@ -128,7 +128,7 @@ requests = ">=2.7.9"
 [[package]]
 category = "dev"
 description = "Cross-platform colored terminal text."
-marker = "platform_system == \"Windows\" or sys_platform == \"win32\" or python_version >= \"3.0\" and sys_platform == \"win32\""
+marker = "sys_platform == \"win32\" or platform_system == \"Windows\" or python_version >= \"3.0\" and sys_platform == \"win32\""
 name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
@@ -961,6 +961,22 @@ secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
+category = "dev"
+description = "A rewrite of the builtin doctest module"
+name = "xdoctest"
+optional = false
+python-versions = "*"
+version = "0.14.0"
+
+[package.dependencies]
+six = "*"
+
+[package.extras]
+all = ["six", "pytest", "pytest-cov", "codecov", "scikit-build", "cmake", "ninja", "pybind11", "pygments", "colorama"]
+optional = ["pygments", "colorama"]
+tests = ["pytest", "pytest-cov", "codecov", "scikit-build", "cmake", "ninja", "pybind11"]
+
+[[package]]
 category = "main"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 marker = "python_version < \"3.8\""
@@ -974,7 +990,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "a43412ad7697aa1fe99ad505793ad85b735d2ab7939fcc4f6079808d46594613"
+content-hash = "280366d108fcf4931daac4a77aeac213a9a3f3868c788abf61a7e125dea3b8f4"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -1194,6 +1210,15 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 matplotlib = [
+    {file = "matplotlib-3.3.1-1-cp36-cp36m-win32.whl", hash = "sha256:fab11637734eb14affb9c5e20d44d69429c18b49595d6e67c69295de24827fc4"},
+    {file = "matplotlib-3.3.1-1-cp36-cp36m-win_amd64.whl", hash = "sha256:24392ac1a382ed753505286f1a1483bcfd67ed0c72d51be10c4c2013e386d0b7"},
+    {file = "matplotlib-3.3.1-1-cp37-cp37m-win32.whl", hash = "sha256:c4ffb25b9855bdb6cdaf21bbd4ab2c229be539248304ac5215b94c816ea6e32e"},
+    {file = "matplotlib-3.3.1-1-cp37-cp37m-win_amd64.whl", hash = "sha256:5a42c84264a1acbbf01c073a7bd05a0e80d99f94f10020d613b1b0526af9dcc2"},
+    {file = "matplotlib-3.3.1-1-cp38-cp38-win32.whl", hash = "sha256:bc978374b43737f2bbc4a6ec48e52ae8c92be6278a80d0e2ce92f0eb0841f15c"},
+    {file = "matplotlib-3.3.1-1-cp38-cp38-win_amd64.whl", hash = "sha256:6d0f03079f655ca0a2d2e0bf49c28e1ec43d9d544c33d8da1a88765f23018ecc"},
+    {file = "matplotlib-3.3.1-1-cp39-cp39-win32.whl", hash = "sha256:2375f039b8c6ad6c1d03f01bf31f086bbbf997bf25e246f3b67f69969cde3d98"},
+    {file = "matplotlib-3.3.1-1-cp39-cp39-win_amd64.whl", hash = "sha256:233bef5e3b3494f3b7057595ca814f23ba0ce67a03632ddf677be5132128b3db"},
+    {file = "matplotlib-3.3.1-1-pp36-pypy36_pp73-win32.whl", hash = "sha256:f62c0b9a5d38c26673a8862cbae4d26cffcda260848e4278246b4e00f5a95eaf"},
     {file = "matplotlib-3.3.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:282f8a077a1217f9f2ac178596f27c1ae94abbc6e7b785e1b8f25e83918e9199"},
     {file = "matplotlib-3.3.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:83ae7261f4d5ab387be2caee29c4f499b1566f31c8ac97a0b8ab61afd9e3da92"},
     {file = "matplotlib-3.3.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1f9cf2b8500b833714a193cb24281153f5072d55b2e486009f1e81f0b7da3410"},
@@ -1302,8 +1327,6 @@ pillow = [
     {file = "Pillow-7.2.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:5e51ee2b8114def244384eda1c82b10e307ad9778dac5c83fb0943775a653cd8"},
     {file = "Pillow-7.2.0-cp38-cp38-win32.whl", hash = "sha256:725aa6cfc66ce2857d585f06e9519a1cc0ef6d13f186ff3447ab6dff0a09bc7f"},
     {file = "Pillow-7.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:a060cf8aa332052df2158e5a119303965be92c3da6f2d93b6878f0ebca80b2f6"},
-    {file = "Pillow-7.2.0-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:9c87ef410a58dd54b92424ffd7e28fd2ec65d2f7fc02b76f5e9b2067e355ebf6"},
-    {file = "Pillow-7.2.0-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:e901964262a56d9ea3c2693df68bc9860b8bdda2b04768821e4c44ae797de117"},
     {file = "Pillow-7.2.0-pp36-pypy36_pp73-win32.whl", hash = "sha256:25930fadde8019f374400f7986e8404c8b781ce519da27792cbe46eabec00c4d"},
     {file = "Pillow-7.2.0.tar.gz", hash = "sha256:97f9e7953a77d5a70f49b9a48da7776dc51e9b738151b22dacf101641594a626"},
 ]
@@ -1541,6 +1564,10 @@ typing-extensions = [
 urllib3 = [
     {file = "urllib3-1.25.9-py2.py3-none-any.whl", hash = "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"},
     {file = "urllib3-1.25.9.tar.gz", hash = "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527"},
+]
+xdoctest = [
+    {file = "xdoctest-0.14.0-py2.py3-none-any.whl", hash = "sha256:312c0afa79a0a6e29737cc0bc4acdf8299133b70ce7c4d7ed254d6950ec34fff"},
+    {file = "xdoctest-0.14.0.tar.gz", hash = "sha256:f1a218eacb89401cb0547beba684a4d649d1f09b2492a346816c0cf35e36257c"},
 ]
 zipp = [
     {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ sphinx = "^3.2.1"
 codecov = "^2.1.8"
 sphinx_bootstrap_theme = "^0.7.1"
 sphinxcontrib-images = "^0.9.2"
+xdoctest = "^0.14.0"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/src/seaborn_image/_context.py
+++ b/src/seaborn_image/_context.py
@@ -95,12 +95,7 @@ def reset_defaults():
         >>> import seaborn_image as isns
         >>> isns.reset_defaults()
     """
-    # need to set it equal instead of using update method
-    # because we have scalebar keys in our rcParams that are
-    # not originally part of the matplotlib rcParamsDefault
-    # Since the goal of this function is to set everything back
-    # to matplotlib defaults, scalebar should be taken out....
-    mpl.rcParams = mpl.rcParamsDefault
+    mpl.rcParams.update(mpl.rcParamsDefault)
 
 
 def set_image(cmap="deep", origin="lower", interpolation="nearest"):

--- a/src/seaborn_image/_context.py
+++ b/src/seaborn_image/_context.py
@@ -20,16 +20,21 @@ def set_context(mode="paper", fontfamily="sans-serif", fontweight="normal", rc=N
     Set context for images with mode, fontfamily and fontweight. Additional,
     rc params can also be passed as dict
 
-    Args:
-        mode (str, optional): context mode. Options are 'paper', 'notebook',
-            'presentation', 'talk' and 'poster'. Defaults to "talk".
-        fontfamily (str, optional): font-family to use. Defaults to "arial".
-        fontweight (str, optional): font-weight to use. Options include 'normal'
-            and 'bold'. Defaults to "bold".
-        rc (dict, optional): additional rc params to be passed to matplotlib.
-            Defaults to None.
+    Parameters
+    ----------
+    mode : str, optional
+        Plotting context mode. Depending on the context, axes width, fontsize, layout etc.
+        are scaled. Options are 'paper', 'notebook', 'presentation', 'talk' and 'poster',
+        by default "paper".
+    fontfamily : str, optional
+        Font-family to use, by default "sans-serif".
+    fontweight : str, optional
+        Font-weight to use. Options include 'normal' and 'bold', by default "bold".
+    rc : dict, optional
+        Additional `matplotlib.rcParams` to be passed to matplotlib, by default None.
 
-    Example:
+    Examples
+    --------
         >>> import seaborn_image as isns
         >>> isns.set_context(mode="poster", fontfamily="sans-serif")
         >>> isns.set_context(rc={"axes.edgecolor": "red"})
@@ -68,13 +73,15 @@ def set_save_context(dpi=300):
     """
     Set dpi for saving figures to disk
 
-    Args:
-        dpi (int, optional): image dpi. Defaults to 300.
+    Parameters
+    ----------
+    dpi : int, optional
+        Image dpi for saving, by default 300.
 
-    Example:
+    Examples
+    --------
         >>> import seaborn_image as isns
         >>> isns.set_save_context(dpi=200)
-
     """
     plt.rc("savefig", dpi=dpi, bbox="tight")
 
@@ -83,27 +90,29 @@ def reset_defaults():
     """
     Reset rcParams to matplotlib defaults
 
-    Example:
+    Examples
+    --------
         >>> import seaborn_image as isns
         >>> isns.reset_defaults()
-
     """
     mpl.rcParams.update(mpl.rcParamsDefault)
 
 
-def set_image(cmap="ice", origin="lower", interpolation="nearest"):
+def set_image(cmap="deep", origin="lower", interpolation="nearest"):
     """
     Set deaults for plotting images
 
-    Args:
-        cmap (str, optional): Colormap to use accross images.
-            Defaults to "viridis".
-        origin (str, optional): image origin - same as in matplotlib imshow.
-            Defaults to "lower".
-        interpolation (str, optional): image interpolation - same as in matplotlib imshow.
-            Defaults to "nearest".
+    Parameters
+    ----------
+    cmap : str, optional
+        Colormap to use accross images, by default to "deep".
+    origin : str, optional
+        Image origin - same as in `matplotlib.pyplot.imshow`, by default "lower".
+    interpolation : str, optional
+        Image interpolation - same as in `matplotlib.pyplot.imshow`, by default "nearest".
 
-    Example:
+    Examples
+    --------
         >>> import seaborn_image as isns
         >>> isns.set_image(cmap="inferno", interpolation="bicubic")
 
@@ -131,20 +140,28 @@ def set_scalebar(
     argument, use the `rc` parameter. Refer to https://github.com/ppinard/matplotlib-scalebar
     for more information on additional parameters.
 
-    Args:
-        color(str, optional): color of the scalebar. Defaults to "white".
-        location (str, optional): scalebar location on the image (same as `matplotlib` legend).
-            Defaults to "lower right".
-        height_fraction (float, optional): Defaults to 0.025.
-        length_fraction (float, optional): Defaults to 0.3
-        scale_loc (str, optional): location of the scale number and units with respect to the bar.
-            Defaults to "top".
-        box_alpha (float, optional): transparency of the box that contains the scalebar artist.
-            Defaults to 0.
-        rc (dict, optional): dictionary of scalebar properties to be set.
-            Defaults to None.
+    Parameters
+    ----------
+        color : str, optional
+            Color of the scalebar, by default "white".
+        location : str, optional
+            Scalebar location on the image (same as `matplotlib` legend).
+            by default "lower right".
+        height_fraction : float, optional
+            By default 0.025.
+        length_fraction : float, optional
+            By default 0.3
+        scale_loc :str, optional
+            Location of the scale number and units with respect to
+            the bar, by default "top".
+        box_alpha : float, optional
+            Transparency of the box that contains
+            the scalebar artist, by default 0.
+        rc : dict, optional
+            Dictionary of scalebar properties to be set, by default None.
 
-    Example:
+    Examples
+    --------
         >>> import seaborn_image as isns
         >>> isns.set_scalebar(color = "red")
         >>> isns.set_scalebar(scale_loc = "bottom")

--- a/src/seaborn_image/_context.py
+++ b/src/seaborn_image/_context.py
@@ -95,7 +95,12 @@ def reset_defaults():
         >>> import seaborn_image as isns
         >>> isns.reset_defaults()
     """
-    mpl.rcParams.update(mpl.rcParamsDefault)
+    # need to set it equal instead of using update method
+    # because we have scalebar keys in our rcParams that are
+    # not originally part of the matplotlib rcParamsDefault
+    # Since the goal of this function is to set everything back
+    # to matplotlib defaults, scalebar should be taken out....
+    mpl.rcParams = mpl.rcParamsDefault
 
 
 def set_image(cmap="deep", origin="lower", interpolation="nearest"):

--- a/src/seaborn_image/_context.py
+++ b/src/seaborn_image/_context.py
@@ -85,7 +85,7 @@ def reset_defaults():
 
     Example:
         >>> import seaborn_image as isns
-        >>> isns.reset_deafults()
+        >>> isns.reset_defaults()
 
     """
     mpl.rcParams.update(mpl.rcParamsDefault)

--- a/src/seaborn_image/_core.py
+++ b/src/seaborn_image/_core.py
@@ -31,14 +31,11 @@ class _SetupImage(object):
         vmax=None,
         robust=False,
         perc=None,
-        title=None,
-        fontdict=None,
         dx=None,
         units=None,
         dimension=None,
         cbar=None,
         orientation="v",
-        cbar_fontdict=None,
         cbar_label=None,
         cbar_ticks=None,
         showticks=False,
@@ -52,14 +49,11 @@ class _SetupImage(object):
         self.vmax = vmax
         self.robust = robust
         self.perc = perc
-        self.title = title
-        self.fontdict = fontdict
         self.dx = dx
         self.units = units
         self.dimension = dimension
         self.cbar = cbar
         self.orientation = orientation
-        self.cbar_fontdict = cbar_fontdict
         self.cbar_label = cbar_label
         self.cbar_ticks = cbar_ticks
         self.showticks = showticks
@@ -72,12 +66,6 @@ class _SetupImage(object):
         else:
             f = plt.gcf()
             ax = self.ax
-
-        if self.fontdict is not None:
-            _check_dict(self.fontdict)
-
-        if self.title is not None:
-            ax.set_title(self.title, fontdict=self.fontdict)
 
         return f, ax
 
@@ -187,11 +175,8 @@ class _SetupImage(object):
             if self.cbar_ticks is not None:
                 cb.set_ticks(self.cbar_ticks)
 
-            if self.cbar_fontdict is not None:
-                _check_dict(self.cbar_fontdict)
-
             if self.cbar_label is not None:
-                cb.set_label(self.cbar_label, fontdict=self.cbar_fontdict)
+                cb.set_label(self.cbar_label)
 
         else:
             cax = None

--- a/src/seaborn_image/_core.py
+++ b/src/seaborn_image/_core.py
@@ -16,11 +16,6 @@ _DIMENSIONS = {
 }
 
 
-def _check_dict(dictionary):
-    if not isinstance(dictionary, dict):
-        raise TypeError(f"{dictionary} must be a dictionary")
-
-
 class _SetupImage(object):
     def __init__(
         self,

--- a/src/seaborn_image/_filters.py
+++ b/src/seaborn_image/_filters.py
@@ -54,79 +54,118 @@ def filterplot(
     Apply N-dimensional filters and plot the filterd data as 2-D image with options to
     add scalebar, colorbar, titles and configure similar to `imgplot`
 
-    Args:
-        data: Image data (array-like). Supported array shapes are all
-            `matplotlib.pyplot.imshow` array shapes
-        filt (str or callable, optional): Filter name or function to be applied.
-            Filter name can be a string from `seaborn_image.implemented_filters` or a callable
-            filter. Defaults to "gaussian".
-        cmap (str or `matplotlib.colors.Colormap`, optional): Colormap for image.
-            Can be a seaborn-image colormap or default matplotlib colormaps or
-            any other colormap converted to a matplotlib colormap. Defaults to None.
-        vmin (float, optional): Minimum data value that colormap covers. Defaults to None.
-        vmax (float, optional): Maximum data value that colormap covers. Defaults to None.
-        robust (bool, optional): If True and vmin or vmax are None, colormap range is calculated
-            based on the percentiles defined in `percentile` parameter. Defaults to False.
-        perc (tuple or list, optional): If `robust` is True, colormap range is calculated based
-            on the percentiles specified instead of the extremes. Defaults to (2,98) - 2nd and 98th
-            percentiles for min and max values.
-        dx (float, optional): Size per pixel of the image data. If scalebar
-            is required, `dx` and `units` must be sepcified. Defaults to None.
-        units (str, optional): Units of `dx`. Defaults to None.
-        dimension (str, optional): dimension of `dx` and `units`.
-            Options include :
-                - "si" : scale bar showing km, m, cm, etc.
-                - "imperial" : scale bar showing in, ft, yd, mi, etc.
-                - "si-reciprocal" : scale bar showing 1/m, 1/cm, etc.
-                - "angle" : scale bar showing °, ʹ (minute of arc) or ʹʹ (second of arc).
-                - "pixel" : scale bar showing px, kpx, Mpx, etc.
-            Defaults to None.
-        describe (bool, optional): Brief statistical description of the original and filterd
-            image. Defaults to False.
-        cbar (bool, optional): Specify if a colorbar is required or not.
-            Defaults to True.
-        orientation (str, optional): Specify the orientaion of colorbar.
-            Option include :
-                - 'h' or 'horizontal' for a horizontal colorbar to the bottom of the image.
-                - 'v' or 'vertical' for a vertical colorbar to the right of the image.
-            Defaults to 'v'.
-        cbar_label (str, optional): Colorbar label. Defaults to None.
-        cbar_ticks (list, optional): List of colorbar ticks. If None, min and max of
-            the data are used. If `vmin` and `vmax` are specified, `vmin` and `vmax` values
-            are used for colorbar ticks. Defaults to None.
-        showticks (bool, optional): Show image x-y axis ticks. Defaults to False.
-        despine (bool, optional): Remove axes spines from image axes as well as colorbar axes.
-            Defaults to True.
-        **kwargs : Any additional parameters to be passed to the specific filt chosen.
-            For instance, "sigma" or "size" or "mode" etc.
+    Parameters
+    ----------
+    data : array-like
+        Image data. Supported array shapes are all `matplotlib.pyplot.imshow` array shapes
+    filt : str or callable, optional
+        Filter name or function to be applied.
+        Filter name can be a string from `seaborn_image.implemented_filters` or a callable
+        filter. Defaults to "gaussian".
+    ax : `matplotlib.axes.Axes`, optional
+        Matplotlib axes to plot image on. If None, figure and axes are auto-generated, by default None
+    cmap : str or `matplotlib.colors.Colormap`, optional
+        Colormap for image. Can be a seaborn-image colormap or default matplotlib colormaps or
+        any other colormap converted to a matplotlib colormap, by default None
+    gray : bool, optional
+        If True and data is RGB image, it will be converted to grayscale.
+        If True and cmap is None, cmap will be set to "gray", by default None
+    vmin : float, optional
+        Minimum data value that colormap covers, by default None
+    vmax : float, optional
+        Maximum data value that colormap covers, by default None
+    robust : bool, optional
+        If True and vmin or vmax are None, colormap range is calculated
+        based on the percentiles defined in `perc` parameter, by default False
+    perc : tuple or list, optional
+        If `robust` is True, colormap range is calculated based
+        on the percentiles specified instead of the extremes, by default (2, 98) -
+        2nd and 98th percentiles for min and max values
+    dx : float, optional
+        Size per pixel of the image data. Specifying `dx` and `units` adds a scalebar
+        to the image, by default None
+    units : str, optional
+        Units of `dx`, by default None
+    dimension : str, optional
+        dimension of `dx` and `units`, by default None
+        Options include (similar to `matplotlib_scalebar`):
+            - "si" : scale bar showing km, m, cm, etc.
+            - "imperial" : scale bar showing in, ft, yd, mi, etc.
+            - "si-reciprocal" : scale bar showing 1/m, 1/cm, etc.
+            - "angle" : scale bar showing °, ʹ (minute of arc) or ʹʹ (second of arc)
+            - "pixel" : scale bar showing px, kpx, Mpx, etc.
+    describe : bool, optional
+        Brief statistical description of the data, by default True
+    cbar : bool, optional
+        Specify if a colorbar is to be added to the image, by default True.
+        If `data` is RGB image, cbar is False
+    orientation : str, optional
+        Specify the orientaion of colorbar, by default "v".
+        Options include :
+            - 'h' or 'horizontal' for a horizontal colorbar to the bottom of the image.
+            - 'v' or 'vertical' for a vertical colorbar to the right of the image.
+    cbar_label : str, optional
+        Colorbar label, by default None
+    cbar_ticks : list, optional
+        List of colorbar ticks, by default None
+    showticks : bool, optional
+        Show image x-y axis ticks, by default False
+    despine : bool, optional
+        Remove axes spines from image axes as well as colorbar axes, by default True
+    **kwargs : optional
+        Any additional parameters to be passed to the specific `filt` chosen.
+        For instance, "sigma" or "size" or "mode" etc.
 
-    Raises:
-        TypeError: if `filt` is not a string type or callable function
-        NotImplementedError: if a `filt` that is not implemented is specified
-        TypeError: if `describe` is not a `bool`
-
-    Returns:
+    Returns
+    -------
         (tuple): tuple containing:
 
             (`matplotlib.axes.Axes`): Matplotlib axes where the image is drawn.
             (`matplotlib.axes.Axes`): Colorbar axes
             (`numpy.array`): Filtered image data
 
-    Example:
+    Raises
+    ------
+        TypeError
+            if `filt` is not a string type or callable function
+        NotImplementedError
+            if a `filt` that is not implemented is specified
+        TypeError
+            if `describe` is not a `bool`
+
+    Examples
+    --------
+
+    Use default gaussian filter
+
+    .. plot::
+        :context: close-figs
+
         >>> import seaborn_image as isns
+        >>> img = isns.load_image("polymer")
+        >>> isns.filterplot(img, sigma=3)
 
-        >>> # use default gaussian filter
-        >>> isns.filterplot(data, sigma=3)
+    Specify an image filter with specific parameters
 
-        >>> # specify a filt with specific parameter
-        >>> isns.filterplot(data, "percentile", percentile=35, size=10)
+    .. plot::
+        :context: close-figs
 
-        >>> # callable filter
+        >>> isns.filterplot(img, "percentile", percentile=35, size=10)
+
+    `filter` can also be a function
+
+    .. plot::
+        :context: close-figs
+
         >>> import scipy.ndimage as ndi
-        >>> isns.filterplot(data, ndi.gaussian_filter, sigma=3)
+        >>> isns.filterplot(img, ndi.gaussian_filter, sigma=2.5)
 
-        >>> # specify scalebar for the filterplot
-        >>> isns.filterplot(data, "sobel", dx=3, units="um")
+    Specify other image parameters for visualization along with the filter
+
+    .. plot::
+        :context: close-figs
+
+        >>> isns.filterplot(img, "sobel", dx=15, units="nm", cmap="acton")
     """
 
     if not isinstance(describe, bool):

--- a/src/seaborn_image/_filters.py
+++ b/src/seaborn_image/_filters.py
@@ -45,12 +45,9 @@ def filterplot(
     cbar=True,
     orientation="v",
     cbar_label=None,
-    cbar_fontdict=None,
     cbar_ticks=None,
     showticks=False,
     despine=True,
-    title=None,
-    title_fontdict=None,
     **kwargs,
 ):
     """
@@ -94,16 +91,12 @@ def filterplot(
                 - 'v' or 'vertical' for a vertical colorbar to the right of the image.
             Defaults to 'v'.
         cbar_label (str, optional): Colorbar label. Defaults to None.
-        cbar_fontdict (dict, optional): Font specifications for colorbar label - `cbar_label`.
-            Defaults to None.
         cbar_ticks (list, optional): List of colorbar ticks. If None, min and max of
             the data are used. If `vmin` and `vmax` are specified, `vmin` and `vmax` values
             are used for colorbar ticks. Defaults to None.
         showticks (bool, optional): Show image x-y axis ticks. Defaults to False.
         despine (bool, optional): Remove axes spines from image axes as well as colorbar axes.
             Defaults to True.
-        title (str, optional): Image title. Defaults to None.
-        title_fontdict (dict, optional): Font specifications for `title`. Defaults to None.
         **kwargs : Any additional parameters to be passed to the specific filt chosen.
             For instance, "sigma" or "size" or "mode" etc.
 
@@ -176,7 +169,6 @@ def filterplot(
         cbar=cbar,
         orientation=orientation,
         cbar_label=cbar_label,
-        cbar_fontdict=cbar_fontdict,
         cbar_ticks=cbar_ticks,
         showticks=showticks,
         despine=despine,
@@ -203,11 +195,8 @@ def fftplot(
     cmap=None,
     cbar=True,
     cbar_label=None,
-    cbar_fontdict=None,
     cbar_ticks=None,
     showticks=False,
-    title=None,
-    title_fontdict=None,
 ):
 
     if cmap is None:
@@ -226,12 +215,9 @@ def fftplot(
         ax=ax,
         cmap=cmap,
         cbar=cbar,
-        cbar_fontdict=cbar_fontdict,
         cbar_ticks=cbar_ticks,
         showticks=showticks,
         describe=False,
-        title=title,
-        title_fontdict=title_fontdict,
     )
 
     return ax, cax

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -31,12 +31,9 @@ def imgplot(
     cbar=True,
     orientation="v",
     cbar_label=None,
-    cbar_fontdict=None,
     cbar_ticks=None,
     showticks=False,
     despine=True,
-    title=None,
-    title_fontdict=None,
 ):
     """Plot data as a 2-D image with options to ignore outliers, add scalebar, colorbar, title.
 
@@ -88,18 +85,12 @@ def imgplot(
             - 'v' or 'vertical' for a vertical colorbar to the right of the image.
     cbar_label : str, optional
         Colorbar label, by default None
-    cbar_fontdict : dict, optional
-        Font specifications for colorbar label, by default None
     cbar_ticks : list, optional
         List of colorbar ticks, by default None
     showticks : bool, optional
         Show image x-y axis ticks, by default False
     despine : bool, optional
         Remove axes spines from image axes as well as colorbar axes, by default True
-    title : [type], optional
-        Image title, by default None
-    title_fontdict : [type], optional
-        Font specifications for `title`, by default None
 
     Returns
     -------
@@ -127,15 +118,9 @@ def imgplot(
     TypeError
         if `cbar_label` is not str
     TypeError
-        if `cbar_fontdict` is not dict
-    TypeError
         if `showticks` is not bool
     TypeError
         if `despine` is not bool
-    TypeError
-        if `title` is not str
-    TypeError
-        if `title_fontdict` is not dict
     AssertionError
         if `len(perc)` is not equal to 2
     AssertionError
@@ -191,7 +176,6 @@ def imgplot(
 
         >>> from skimage.data import astronaut
         >>> isns.imgplot(astronaut(), gray=True)
-
 
     Change colorbar orientation
 
@@ -249,23 +233,11 @@ def imgplot(
         if not isinstance(cbar_label, str):
             raise TypeError
 
-    if cbar_fontdict is not None:
-        if not isinstance(cbar_fontdict, dict):
-            raise TypeError
-
     if not isinstance(showticks, bool):
         raise TypeError
 
     if not isinstance(despine, bool):
         raise TypeError
-
-    if title is not None:
-        if not isinstance(title, str):
-            raise TypeError
-
-    if title_fontdict is not None:
-        if not isinstance(title_fontdict, dict):
-            raise TypeError
 
     if isinstance(data, np.ndarray):
         if data.ndim == 3:
@@ -291,12 +263,9 @@ def imgplot(
         cbar=cbar,
         orientation=orientation,
         cbar_label=cbar_label,
-        cbar_fontdict=cbar_fontdict,
         cbar_ticks=cbar_ticks,
         showticks=showticks,
         despine=despine,
-        title=title,
-        fontdict=title_fontdict,
     )
 
     f, ax, cax = img_plotter.plot()
@@ -330,12 +299,9 @@ def imghist(
     cbar=True,
     orientation="v",
     cbar_label=None,
-    cbar_fontdict=None,
     cbar_ticks=None,
     showticks=False,
     despine=True,
-    title=None,
-    title_fontdict=None,
 ):
     """Plot data as a 2-D image with histogram showing the distribution of
     the data. Options to add scalebar, colorbar, title.
@@ -390,18 +356,12 @@ def imghist(
             - 'v' or 'vertical' for a vertical colorbar to the right of the image.
     cbar_label : str, optional
         Colorbar label, by default None
-    cbar_fontdict : dict, optional
-        Font specifications for colorbar label, by default None
     cbar_ticks : list, optional
         List of colorbar ticks, by default None
     showticks : bool, optional
         Show image x-y axis ticks, by default False
     despine : bool, optional
         Remove axes spines from image axes as well as colorbar axes, by default True
-    title : [type], optional
-        Image title, by default None
-    title_fontdict : [type], optional
-        Font specifications for `title`, by default None
 
     Returns
     -------
@@ -493,12 +453,9 @@ def imghist(
         cbar=cbar,
         orientation=orientation,
         cbar_label=cbar_label,
-        cbar_fontdict=cbar_fontdict,
         cbar_ticks=cbar_ticks,
         showticks=showticks,
         despine=despine,
-        title=title,
-        title_fontdict=title_fontdict,
     )
 
     if orientation == "vertical":

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -13,6 +13,8 @@ from ._core import _SetupImage
 __all__ = ["imgplot", "imghist"]
 
 
+# TODO implement rgbplot() - which has options
+# to split the channels
 def imgplot(
     data,
     ax=None,
@@ -36,104 +38,186 @@ def imgplot(
     title=None,
     title_fontdict=None,
 ):
-    """
+    """Plot data as a 2-D image with options to ignore outliers, add scalebar, colorbar, title.
 
-    Plot data as a 2-D image with options to ignore outliers, add scalebar, colorbar, title.
+    Parameters
+    ----------
+    data : array-like
+        Image data. Supported array shapes are all `matplotlib.pyplot.imshow` array shapes
+    ax : `matplotlib.axes.Axes`, optional
+        Matplotlib axes to plot image on. If None, figure and axes are auto-generated, by default None
+    cmap : str or `matplotlib.colors.Colormap`, optional
+        Colormap for image. Can be a seaborn-image colormap or default matplotlib colormaps or
+        any other colormap converted to a matplotlib colormap, by default None
+    gray : bool, optional
+        If True and data is RGB image, it will be converted to grayscale.
+        If True and cmap is None, cmap will be set to "gray", by default None
+    vmin : float, optional
+        Minimum data value that colormap covers, by default None
+    vmax : float, optional
+        Maximum data value that colormap covers, by default None
+    robust : bool, optional
+        If True and vmin or vmax are None, colormap range is calculated
+        based on the percentiles defined in `perc` parameter, by default False
+    perc : tuple or list, optional
+        If `robust` is True, colormap range is calculated based
+        on the percentiles specified instead of the extremes, by default (2, 98) -
+        2nd and 98th percentiles for min and max values
+    dx : float, optional
+        Size per pixel of the image data. Specifying `dx` and `units` adds a scalebar
+        to the image, by default None
+    units : str, optional
+        Units of `dx`, by default None
+    dimension : str, optional
+        dimension of `dx` and `units`, by default None
+        Options include (similar to `matplotlib_scalebar`):
+            - "si" : scale bar showing km, m, cm, etc.
+            - "imperial" : scale bar showing in, ft, yd, mi, etc.
+            - "si-reciprocal" : scale bar showing 1/m, 1/cm, etc.
+            - "angle" : scale bar showing °, ʹ (minute of arc) or ʹʹ (second of arc)
+            - "pixel" : scale bar showing px, kpx, Mpx, etc.
+    describe : bool, optional
+        Brief statistical description of the data, by default True
+    cbar : bool, optional
+        Specify if a colorbar is to be added to the image, by default True.
+        If `data` is RGB image, cbar is False
+    orientation : str, optional
+        Specify the orientaion of colorbar, by default "v".
+        Options include :
+            - 'h' or 'horizontal' for a horizontal colorbar to the bottom of the image.
+            - 'v' or 'vertical' for a vertical colorbar to the right of the image.
+    cbar_label : str, optional
+        Colorbar label, by default None
+    cbar_fontdict : dict, optional
+        Font specifications for colorbar label, by default None
+    cbar_ticks : list, optional
+        List of colorbar ticks, by default None
+    showticks : bool, optional
+        Show image x-y axis ticks, by default False
+    despine : bool, optional
+        Remove axes spines from image axes as well as colorbar axes, by default True
+    title : [type], optional
+        Image title, by default None
+    title_fontdict : [type], optional
+        Font specifications for `title`, by default None
 
-    Args:
-        data: Image data (array-like). Supported array shapes are all
-            `matplotlib.pyplot.imshow` array shapes
-        ax (`matplotlib.axes.Axes`, optional): Matplotlib axes to plot image on.
-            If None, figure and axes are auto-generated. Defaults to None.
-        cmap (str or `matplotlib.colors.Colormap`, optional): Colormap for image.
-            Can be a seaborn-image colormap or default matplotlib colormaps or
-            any other colormap converted to a matplotlib colormap. Defaults to None.
-        gray (bool, optional): If True and data is RGB image, it will be converted to grayscale.
-            If True and cmap is None, cmap will be set to "gray".
-        vmin (float, optional): Minimum data value that colormap covers. Defaults to None.
-        vmax (float, optional): Maximum data value that colormap covers. Defaults to None.
-        robust (bool, optional): If True and vmin or vmax are None, colormap range is calculated
-            based on the percentiles defined in `percentile` parameter. Defaults to False.
-        perc (tuple or list, optional): If `robust` is True, colormap range is calculated based
-            on the percentiles specified instead of the extremes. Defaults to (2,98) - 2nd and 98th
-            percentiles for min and max values.
-        dx (float, optional): Size per pixel of the image data. If scalebar
-            is required, `dx` and `units` must be sepcified. Defaults to None.
-        units (str, optional): Units of `dx`. Defaults to None.
-        dimension (str, optional): dimension of `dx` and `units`.
-            Options include (similar to `matplotlib_scalebar`):
-                - "si" : scale bar showing km, m, cm, etc.
-                - "imperial" : scale bar showing in, ft, yd, mi, etc.
-                - "si-reciprocal" : scale bar showing 1/m, 1/cm, etc.
-                - "angle" : scale bar showing °, ʹ (minute of arc) or ʹʹ (second of arc).
-                - "pixel" : scale bar showing px, kpx, Mpx, etc.
-            Defaults to None.
-        describe (bool, optional): Brief statistical description of the data.
-            Defaults to True.
-        cbar (bool, optional): Specify if a colorbar is required or not.
-            Defaults to True.
-        orientation (str, optional): Specify the orientaion of colorbar.
-            Option include :
-                - 'h' or 'horizontal' for a horizontal colorbar to the bottom of the image.
-                - 'v' or 'vertical' for a vertical colorbar to the right of the image.
-            Defaults to 'v'.
-        cbar_label (str, optional): Colorbar label. Defaults to None.
-        cbar_fontdict (dict, optional): Font specifications for colorbar label - `cbar_label`.
-            Defaults to None.
-        cbar_ticks (list, optional): List of colorbar ticks. If None, min and max of
-            the data are used. If `vmin` and `vmax` are specified, `vmin` and `vmax` values
-            are used for colorbar ticks. Defaults to None.
-        showticks (bool, optional): Show image x-y axis ticks. Defaults to False.
-        despine (bool, optional): Remove axes spines from image axes as well as colorbar axes.
-            Defaults to True.
-        title (str, optional): Image title. Defaults to None.
-        title_fontdict (dict, optional): [Font specifications for `title`. Defaults to None.
+    Returns
+    -------
+    `matplotlib.figure.Figure`
+        Matplotlib figure.
+    `matplotlib.axes.Axes`
+        Matplotlib axes where the image is drawn.
+    `matplotlib.axes.Axes`
+        Colorbar axes
 
-    Raises:
-        TypeError: if `cmap` is not str or `matplotlib.colors.Colormap`
-        TypeError: if `ax` is not `matplotlib.axes.Axes`
-        TypeError: if `describe` is not bool
-        TypeError: if `robust` is not bool
-        TypeError: if `cbar` is not bool
-        TypeError: if `orientation` is not str
-        TypeError: if `cbar_label` is not str
-        TypeError: if `cbar_fontdict` is not dict
-        TypeError: if `showticks` is not bool
-        TypeError: if `despine` is not bool
-        TypeError: if `title` is not str
-        TypeError: if `title_fontdict` is not dict
-        AssertionError: if `len(perc)` is not equal to 2
-        AssertionError: if the first element of `perc` is greater than the second
+    Raises
+    ------
+    TypeError
+        if `cmap` is not str or `matplotlib.colors.Colormap`
+    TypeError
+        if `ax` is not `matplotlib.axes.Axes`
+    TypeError
+        if `describe` is not bool
+    TypeError
+        if `robust` is not bool
+    TypeError
+        if `cbar` is not bool
+    TypeError
+        if `orientation` is not str
+    TypeError
+        if `cbar_label` is not str
+    TypeError
+        if `cbar_fontdict` is not dict
+    TypeError
+        if `showticks` is not bool
+    TypeError
+        if `despine` is not bool
+    TypeError
+        if `title` is not str
+    TypeError
+        if `title_fontdict` is not dict
+    AssertionError
+        if `len(perc)` is not equal to 2
+    AssertionError
+        if the first element of `perc` is greater than the second
 
-    Returns:
-        (tuple): tuple containing:
-            (`matplotlib.figure.Figure`): Matplotlib figure.
-            (`matplotlib.axes.Axes`): Matplotlib axes where the image is drawn.
-            (`matplotlib.axes.Axes`): Colorbar axes
+    Examples
+    --------
 
-    Example:
+    Plot image
+
+    .. plot::
+        :context: close-figs
+
         >>> import seaborn_image as isns
+        >>> img = isns.load_image("polymer")
+        >>> isns.imgplot(img)
 
-        >>> isns.imgplot(data)
+    Add a scalebar
 
-        >>> # add a scalebar
-        >>> isns.imgplot(data, dx=2, units="nm")
+    .. plot::
+        :context: close-figs
 
-        >>> # specify a colormap
-        >>> isns.imgplot(data, cmap="deep")
+        >>> isns.imgplot(img, dx=15, units="nm")
 
-        >>> # convert RGB image to grayscale
-        >>> isns.imgplot(data, gray=True)
+    Change colormap
 
-        >>> # exclude the outliers
-        >>> isns.imgplot(data, robust=True)
+    .. plot::
+        :context: close-figs
 
-        >>> # change colorbar orientation
-        >>> isns.imgplot(data, orientation="h") # horizontal
-        >>> isns.imgplot(data, orientation="v") # vertical
+        >>> isns.imgplot(img, cmap="deep")
 
-        >>> # add a colorbar label
-        >>> isns.imgplot(data, cbar_label="Label (au)")
+    Rescale colormap to exclude outliers while plotting
+
+    Image with outliers
+
+    .. plot::
+        :context: close-figs
+
+        >>> img_out = isns.load_image("polymer outliers")
+        >>> isns.imgplot(img_out)
+
+    Rescale colormap using `robust` parameter
+
+    .. plot::
+        :context: close-figs
+
+        >>> isns.imgplot(img_out, robust=True, perc=(2,99.99))
+
+    Convert RGB image to grayscale
+
+    .. plot::
+        :context: close-figs
+
+        >>> from skimage.data import astronaut
+        >>> isns.imgplot(astronaut(), gray=True)
+
+
+    Change colorbar orientation
+
+    .. plot::
+        :context: close-figs
+
+        >>> isns.imgplot(img, orientation="h") # horizontal
+
+    .. plot::
+        :context: close-figs
+
+        >>> isns.imgplot(img, orientation="v") # vertical
+
+    Add colorbar label
+
+    .. plot::
+        :context: close-figs
+
+        >>> isns.imgplot(img, cbar_label="Height (nm)")
+
+    Avoid image and colorbar axes despining
+
+    .. plot::
+        :context: close-figs
+
+        >>> isns.imgplot(img, despine=False)
     """
 
     # TODO add vmin, vmax, dx, units to checks
@@ -229,6 +313,8 @@ def imgplot(
     return f, ax, cax
 
 
+# TODO implement a imgdist function with more distributions
+# TODO add height, aspect parameter
 def imghist(
     data,
     cmap=None,
@@ -254,70 +340,117 @@ def imghist(
     """Plot data as a 2-D image with histogram showing the distribution of
     the data. Options to add scalebar, colorbar, title.
 
-    Args:
-        data: Image data (array-like). Supported array shapes are all
-            `matplotlib.pyplot.imshow` array shapes
-        cmap (str or `matplotlib.colors.Colormap`, optional): Colormap for image.
-            Can be a seaborn-image colormap or default matplotlib colormaps or
-            any other colormap converted to a matplotlib colormap. Defaults to None.
-        bins (int, optional): Number of histogram bins. Defaults to None. If None, 'auto'
-            is used.
-        vmin (float, optional): Minimum data value that colormap covers. Defaults to None.
-        vmax (float, optional): Maximum data value that colormap covers. Defaults to None.
-        robust (bool, optional): If True and vmin or vmax are None, colormap range is calculated
-            based on the percentiles defined in `percentile` parameter. Defaults to False.
-        perc (tuple or list, optional): If `robust` is True, colormap range is calculated based
-            on the percentiles specified instead of the extremes. Defaults to (2,98) - 2nd and 98th
-            percentiles for min and max values.
-        dx (float, optional): Size per pixel of the image data. If scalebar
-            is required, `dx` and `units` must be sepcified. Defaults to None.
-        units (str, optional): Units of `dx`. Defaults to None.
-        dimension (str, optional): dimension of `dx` and `units`.
-            Options include :
-                - "si" : scale bar showing km, m, cm, etc.
-                - "imperial" : scale bar showing in, ft, yd, mi, etc.
-                - "si-reciprocal" : scale bar showing 1/m, 1/cm, etc.
-                - "angle" : scale bar showing °, ʹ (minute of arc) or ʹʹ (second of arc).
-                - "pixel" : scale bar showing px, kpx, Mpx, etc.
-            Defaults to None.
-        describe (bool, optional): Brief statistical description of the data.
-            Defaults to True.
-        cbar (bool, optional): Specify if a colorbar is required or not.
-            Defaults to True.
-        orientation (str, optional): Specify the orientaion of colorbar.
-            Option include :
-                - 'h' or 'horizontal' for a horizontal colorbar and histogram to the bottom of the image.
-                - 'v' or 'vertical' for a vertical colorbar and histogram to the right of the image.
-            Defaults to 'v'.
-        cbar_label (str, optional): Colorbar label. Defaults to None.
-        cbar_fontdict (dict, optional): Font specifications for colorbar label - `cbar_label`.
-            Defaults to None.
-        cbar_ticks (list, optional): List of colorbar ticks. If None, min and max of
-            the data are used. If `vmin` and `vmax` are specified, `vmin` and `vmax` values
-            are used for colorbar ticks. Defaults to None.
-        showticks (bool, optional): Show image x-y axis ticks. Defaults to False.
-        despine (bool, optional): Remove axes spines from image axes as well as colorbar axes.
-            Defaults to True.
-        title (str, optional): Image title. Defaults to None.
-        title_fontdict (dict, optional): [Font specifications for `title`. Defaults to None.
+    Parameters
+    ----------
+    data : array-like
+        Image data. Supported array shapes are all `matplotlib.pyplot.imshow` array shapes
+    bins : int, optional
+        Histogram bins, by default None. If None, `auto` is used.
+    ax : `matplotlib.axes.Axes`, optional
+        Matplotlib axes to plot image on. If None, figure and axes are auto-generated, by default None
+    cmap : str or `matplotlib.colors.Colormap`, optional
+        Colormap for image. Can be a seaborn-image colormap or default matplotlib colormaps or
+        any other colormap converted to a matplotlib colormap, by default None
+    gray : bool, optional
+        If True and data is RGB image, it will be converted to grayscale.
+        If True and cmap is None, cmap will be set to "gray", by default None
+    vmin : float, optional
+        Minimum data value that colormap covers, by default None
+    vmax : float, optional
+        Maximum data value that colormap covers, by default None
+    robust : bool, optional
+        If True and vmin or vmax are None, colormap range is calculated
+        based on the percentiles defined in `perc` parameter, by default False
+    perc : tuple or list, optional
+        If `robust` is True, colormap range is calculated based
+        on the percentiles specified instead of the extremes, by default (2, 98) -
+        2nd and 98th percentiles for min and max values
+    dx : float, optional
+        Size per pixel of the image data. Specifying `dx` and `units` adds a scalebar
+        to the image, by default None
+    units : str, optional
+        Units of `dx`, by default None
+    dimension : str, optional
+        dimension of `dx` and `units`, by default None
+        Options include (similar to `matplotlib_scalebar`):
+            - "si" : scale bar showing km, m, cm, etc.
+            - "imperial" : scale bar showing in, ft, yd, mi, etc.
+            - "si-reciprocal" : scale bar showing 1/m, 1/cm, etc.
+            - "angle" : scale bar showing °, ʹ (minute of arc) or ʹʹ (second of arc)
+            - "pixel" : scale bar showing px, kpx, Mpx, etc.
+    describe : bool, optional
+        Brief statistical description of the data, by default True
+    cbar : bool, optional
+        Specify if a colorbar is to be added to the image, by default True.
+        If `data` is RGB image, cbar is False
+    orientation : str, optional
+        Specify the orientaion of colorbar, by default "v".
+        Options include :
+            - 'h' or 'horizontal' for a horizontal colorbar to the bottom of the image.
+            - 'v' or 'vertical' for a vertical colorbar to the right of the image.
+    cbar_label : str, optional
+        Colorbar label, by default None
+    cbar_fontdict : dict, optional
+        Font specifications for colorbar label, by default None
+    cbar_ticks : list, optional
+        List of colorbar ticks, by default None
+    showticks : bool, optional
+        Show image x-y axis ticks, by default False
+    despine : bool, optional
+        Remove axes spines from image axes as well as colorbar axes, by default True
+    title : [type], optional
+        Image title, by default None
+    title_fontdict : [type], optional
+        Font specifications for `title`, by default None
 
-    Raises:
-        TypeError: if `bins` is not int
+    Returns
+    -------
+    `matplotlib.figure.Figure`
+        Matplotlib figure.
+    `matplotlib.axes.Axes`
+        Matplotlib axes where the image is drawn.
+    `matplotlib.axes.Axes`
+        Matplotlib axes where the histogram is drawn.
+    `matplotlib.axes.Axes`
+        Colorbar axes
 
-    Returns:
-        (tuple): tuple containing:
-            (`matplotlib.figure.Figure`): Matplotlib figure.
-            (tuple): tuple containing:
-                (`matplotlib.axes.Axes`): Matplotlib axes where the image is drawn.
-                (`matplotlib.axes.Axes`): Matplotlib axes where the histogram is drawn.
-            (`matplotlib.axes.Axes`): Colorbar axes
+    Raises
+    ------
+    TypeError
+        if `bins` is not a positive integer
 
-    Example:
+    Examples
+    --------
+
+    Plot distribution alongside the image
+
+    .. plot::
+        :context: close-figs
+
         >>> import seaborn_image as isns
-        >>> isns.imghist(data)
-        >>> isns.imghist(data, bins=300) # specify the number of histogram bins
-        >>> isns.imghist(data, dx=2, units="nm") # add a scalebar
-        >>> isns.imghist(data, cmap="deep") # specify a colormap
+        >>> img = isns.load_image("polymer")
+        >>> isns.imghist(img)
+
+    Change the number of bins
+
+    .. plot::
+        :context: close-figs
+
+        >>> isns.imghist(img, bins=300)
+
+    Add a scalebar
+
+    .. plot::
+        :context: close-figs
+
+        >>> isns.imghist(img, dx=15, units="nm")
+
+    Change colormaps
+
+    .. plot::
+        :context: close-figs
+
+        >>> isns.imghist(img, cmap="deep")
     """
 
     if bins is None:

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -73,16 +73,17 @@ class FilterGrid(object):
 
     Examples:
         >>> import seaborn_image as isns
+        >>> img = isns.load_image("polymer")
 
         >>> # Specify a median filter with different `size` parameters along the columns/rows
-        >>> g = isns.FilterGrid(data, "median", col="size", size=[2,3,4,5])
-        >>> g = isns.FilterGrid(data, "median", row="size", size=[2,3,4,5])
+        >>> g = isns.FilterGrid(img, "median", col="size", size=[2,3,4,5])
+        >>> g = isns.FilterGrid(img, "median", row="size", size=[2,3,4,5])
 
         >>> # Use col_wrap to control column display
-        >>> g = isns.FilterGrid(data, "median", col="size", size=[2,3,4,5], col_wrap=3)
+        >>> g = isns.FilterGrid(img, "median", col="size", size=[2,3,4,5], col_wrap=3)
 
         >>> # Use col and row to display different parameters along the columns and rows
-        >>> g = isns.FilterGrid(data,
+        >>> g = isns.FilterGrid(img,
                                 "percentile",
                                 row="percentile",
                                 col="size",
@@ -90,11 +91,11 @@ class FilterGrid(object):
                                 size=[20,25,30])
 
         >>> # Specify additional kwargs for the filter
-        >>> g = isns.FilterGrid(data, "median", col="size", size=[2,3,4,5], mode="reflect")
+        >>> g = isns.FilterGrid(img, "median", col="size", size=[2,3,4,5], mode="reflect")
 
         >>> # General image controls such as changing cmap, scalebar, etc.
-        >>> g = isns.FilterGrid(data, "median", col="size", size=[2,3,4,5], cmap="inferno")
-        >>> g = isns.FilterGrid(data, "median", col="size", size=[2,3,4,5], dx=10, units="nm")
+        >>> g = isns.FilterGrid(img, "median", col="size", size=[2,3,4,5], cmap="inferno")
+        >>> g = isns.FilterGrid(img, "median", col="size", size=[2,3,4,5], dx=10, units="nm")
     """
 
     def __init__(

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -20,82 +20,138 @@ class FilterGrid(object):
     the filters across the rows and columns of the grid. Additional filter
     parameters that are not to be varied can also be passed.
 
-    Args:
-        data : Image data (array-like). Supported array shapes are all
-            `matplotlib.pyplot.imshow` array shapes
-        filt (str or callable): Filter name or function to be applied.
-        row (str, optional): Parameter name that is to be displayed
-            along the row. Defaults to None.
-        col (str, optional): Parameter name that is to be displayed
-            along the column. Defaults to None.
-        col_wrap (int, optional): Number of columns to display if `col`
-            is not None and `row` is None. Defaults to None.
-        height (int, optional): Size of the individual images. Defaults to 3.
-        aspect (int, optional): Aspect ratio of individual images. Defaults to 1.
-        cmap (str or `matplotlib.colors.Colormap`, optional): Image colormap.
-            Defaults to None.
-        dx (float, optional): Size per pixel of the image data. If scalebar
-            is required, `dx` and `units` must be sepcified. Defaults to None.
-        units (str, optional): Units of `dx`. Defaults to None.
-        dimension (str, optional): dimension of `dx` and `units`.
-            Options include :
-                - "si" : scale bar showing km, m, cm, etc.
-                - "imperial" : scale bar showing in, ft, yd, mi, etc.
-                - "si-reciprocal" : scale bar showing 1/m, 1/cm, etc.
-                - "angle" : scale bar showing °, ʹ (minute of arc) or ʹʹ (second of arc).
-                - "pixel" : scale bar showing px, kpx, Mpx, etc.
-            Defaults to None.
-        cbar (bool, optional): Specify if a colorbar is required or not.
-            Defaults to True.
-        orientation (str, optional): Specify the orientaion of colorbar.
-            Option include :
-                - 'h' or 'horizontal' for a horizontal colorbar and histogram to the bottom of the image.
-                - 'v' or 'vertical' for a vertical colorbar and histogram to the right of the image.
-            Defaults to 'v'.
-        cbar_label (str, optional): Colorbar label. Defaults to None.
-        cbar_ticks (list, optional): List of colorbar ticks. If None, min and max of
-            the data are used. If `vmin` and `vmax` are specified, `vmin` and `vmax` values
-            are used for colorbar ticks. Defaults to None.
-        showticks (bool, optional): Show image x-y axis ticks. Defaults to False.
-        despine (bool, optional): Remove axes spines from image axes as well as colorbar axes.
-            Defaults to True.
-        **kwargs : Additional parameters as keyword arguments to be passed to the underlying filter specified.
+    Parameters
+    ----------
+    data :
+        Image data (array-like). Supported array shapes are all
+        `matplotlib.pyplot.imshow` array shapes
+    filt : str or callable
+        Filter name or function to be applied.
+    row : str, optional
+        Parameter name that is to be displayed
+        along the row. Defaults to None.
+    col : str, optional
+        Parameter name that is to be displayed
+        along the column. Defaults to None.
+    col_wrap : int, optional
+        Number of columns to display if `col`
+        is not None and `row` is None. Defaults to None.
+    height : int, optional
+        Size of the individual images. Defaults to 3.
+    aspect : int, optional
+        Aspect ratio of individual images. Defaults to 1.
+    cmap : str or `matplotlib.colors.Colormap`, optional
+        Image colormap. Defaults to None.
+    dx : float, optional
+        Size per pixel of the image data. If scalebar
+        is required, `dx` and `units` must be sepcified. Defaults to None.
+    units : str, optional
+        Units of `dx`. Defaults to None.
+    dimension : str, optional
+        Dimension of `dx` and `units`.
+        Options include :
+            - "si" : scale bar showing km, m, cm, etc.
+            - "imperial" : scale bar showing in, ft, yd, mi, etc.
+            - "si-reciprocal" : scale bar showing 1/m, 1/cm, etc.
+            - "angle" : scale bar showing °, ʹ (minute of arc) or ʹʹ (second of arc).
+            - "pixel" : scale bar showing px, kpx, Mpx, etc.
+        Defaults to None.
+    cbar : bool, optional
+        Specify if a colorbar is required or not.
+        Defaults to True.
+    orientation : str, optional
+        Specify the orientaion of colorbar.
+        Option include :
+            - 'h' or 'horizontal' for a horizontal colorbar and histogram to the bottom of the image.
+            - 'v' or 'vertical' for a vertical colorbar and histogram to the right of the image.
+        Defaults to 'v'.
+    cbar_label : str, optional
+        Colorbar label. Defaults to None.
+    cbar_ticks : list, optional
+        List of colorbar ticks. If None, min and max of
+        the data are used. If `vmin` and `vmax` are specified, `vmin` and `vmax` values
+        are used for colorbar ticks. Defaults to None.
+    showticks : bool, optional
+        Show image x-y axis ticks. Defaults to False.
+    despine : bool, optional
+        Remove axes spines from image axes as well as colorbar axes.
+        Defaults to True.
+    **kwargs : Additional parameters as keyword arguments to be passed to the underlying filter specified.
 
-    Raises:
-        TypeError: if `row` is not a str
-        ValueError: if `row` is specified without passing the parameter as a keword argument
-        TypeError: if `col` is not a str
-        ValueError: if `col` is specified without passing the parameter as a keword argument
-        ValueError: if `col_wrap` is specified when `row` is not `None`
+     Returns
+    -------
+        A `seabron_image.FilterGrid` object
 
-    Returns:
-        A `FilterGrid` object
+    Raises
+    ------
+    TypeError
+        If `row` is not a str
+    ValueError
+        If `row` is specified without passing the parameter as a keword argument
+    TypeError
+        If `col` is not a str
+    ValueError
+        If `col` is specified without passing the parameter as a keword argument
+    ValueError
+        If `col_wrap` is specified when `row` is not `None`
 
-    Examples:
+    Examples
+    --------
+    Specify a filter with different parameters along the columns
+
+    .. plot::
+        :context: close-figs
+
         >>> import seaborn_image as isns
         >>> img = isns.load_image("polymer")
-
-        >>> # Specify a median filter with different `size` parameters along the columns/rows
         >>> g = isns.FilterGrid(img, "median", col="size", size=[2,3,4,5])
+
+    Or rows
+
+    .. plot::
+        :context: close-figs
+
         >>> g = isns.FilterGrid(img, "median", row="size", size=[2,3,4,5])
 
-        >>> # Use col_wrap to control column display
+    Use `col_wrap` to control column display
+
+    .. plot::
+        :context: close-figs
+
         >>> g = isns.FilterGrid(img, "median", col="size", size=[2,3,4,5], col_wrap=3)
 
-        >>> # Use col and row to display different parameters along the columns and rows
-        >>> g = isns.FilterGrid(img,
-                                "percentile",
-                                row="percentile",
-                                col="size",
-                                percentile=[10,20,30],
-                                size=[20,25,30])
+    Use `col` and `row` to display different parameters along the columns and rows
 
-        >>> # Specify additional kwargs for the filter
+    .. plot::
+        :context: close-figs
+
+        >>> g = isns.FilterGrid(img,
+        ...                     "percentile",
+        ...                     row="percentile",
+        ...                     col="size",
+        ...                     percentile=[10,20,30],
+        ...                     size=[20,25,30],)
+
+    Specify additional keyword arguments for the filter
+
+    .. plot::
+        :context: close-figs
+
         >>> g = isns.FilterGrid(img, "median", col="size", size=[2,3,4,5], mode="reflect")
 
-        >>> # General image controls such as changing cmap, scalebar, etc.
-        >>> g = isns.FilterGrid(img, "median", col="size", size=[2,3,4,5], cmap="inferno")
-        >>> g = isns.FilterGrid(img, "median", col="size", size=[2,3,4,5], dx=10, units="nm")
+    General image controls such as changing colormap, scalebar, etc.
+
+    .. plot::
+        :context: close-figs
+
+        >>> g = isns.FilterGrid(
+        ...                     img,
+        ...                     "median",
+        ...                     col="size",
+        ...                     size=[2,3,4,5],
+        ...                     cmap="inferno",
+        ...                     dx=15,
+        ...                     units="nm")
     """
 
     def __init__(

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -53,8 +53,6 @@ class FilterGrid(object):
                 - 'v' or 'vertical' for a vertical colorbar and histogram to the right of the image.
             Defaults to 'v'.
         cbar_label (str, optional): Colorbar label. Defaults to None.
-        cbar_fontdict (dict, optional): Font specifications for colorbar label - `cbar_label`.
-            Defaults to None.
         cbar_ticks (list, optional): List of colorbar ticks. If None, min and max of
             the data are used. If `vmin` and `vmax` are specified, `vmin` and `vmax` values
             are used for colorbar ticks. Defaults to None.
@@ -116,7 +114,6 @@ class FilterGrid(object):
         cbar=True,
         orientation="v",
         cbar_label=None,
-        cbar_fontdict=None,
         cbar_ticks=None,
         showticks=False,
         despine=True,
@@ -217,7 +214,6 @@ class FilterGrid(object):
         self.cbar = cbar
         self.orientation = orientation
         self.cbar_label = cbar_label
-        self.cbar_fontdict = cbar_fontdict
         self.cbar_ticks = cbar_ticks
         self.showticks = showticks
         self.despine = despine
@@ -299,7 +295,6 @@ class FilterGrid(object):
             cbar=self.cbar,
             orientation=self.orientation,
             cbar_label=self.cbar_label,
-            cbar_fontdict=self.cbar_fontdict,
             cbar_ticks=self.cbar_ticks,
             showticks=self.showticks,
             despine=self.despine,

--- a/src/seaborn_image/utils.py
+++ b/src/seaborn_image/utils.py
@@ -190,7 +190,7 @@ def load_image(name):
         try:
             path = "data/PolymerImage.txt"
             img = np.loadtxt(path, skiprows=1)
-        except:  # noqa
+        except OSError:  # pragma: no cover
             # if building docstrings
             path = "../data/PolymerImage.txt"
             img = np.loadtxt(path, skiprows=1)
@@ -201,7 +201,7 @@ def load_image(name):
         try:  # not very pretty fix to the path issue
             path = "data/PolymerImage.txt"
             img = np.loadtxt(path, skiprows=1)
-        except:  # noqa
+        except OSError:  # pragma: no cover
             # if building docstrings
             path = "../data/PolymerImage.txt"
             img = np.loadtxt(path, skiprows=1)

--- a/src/seaborn_image/utils.py
+++ b/src/seaborn_image/utils.py
@@ -1,3 +1,5 @@
+import os
+
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import ticker
@@ -73,11 +75,25 @@ def load_image(name):
     """
 
     if name == "polymer":
-        img = np.loadtxt("data/PolymerImage.txt", skiprows=1)
+        try:
+            path = "data/PolymerImage.txt"
+            img = np.loadtxt(path, skiprows=1)
+        except:  # noqa
+            # if building docstrings
+            path = "../data/PolymerImage.txt"
+            img = np.loadtxt(path, skiprows=1)
+
         img = img * 1e9  # convert height data from m to nm
 
     elif name == "polymer outliers":
-        img = np.loadtxt("data/PolymerImage.txt", skiprows=1)
+        try:  # not very pretty fix to the path issue
+            path = "data/PolymerImage.txt"
+            img = np.loadtxt(path, skiprows=1)
+        except:  # noqa
+            # if building docstrings
+            path = "../data/PolymerImage.txt"
+            img = np.loadtxt(path, skiprows=1)
+
         img = img * 1e9  # convert height data from m to nm
         img[0, 0] = 80  # assign an outlier value to a random pixel
 

--- a/src/seaborn_image/utils.py
+++ b/src/seaborn_image/utils.py
@@ -7,20 +7,132 @@ from matplotlib import ticker
 __all__ = ["scientific_ticks", "despine", "load_image"]
 
 
-def scientific_ticks(ax):
+def scientific_ticks(ax, which="y"):
+    """Convert axis ticks to scientific
+
+    Parameters
+    ----------
+    ax : `matplotlib.axes.Axes`
+        Axis where ticks are to be converted
+    which : str, optional
+        Which axis ticks to convert to scientific, default to "y".
+        Options include : "y", "x", "both"
+
+    Raises
+    ------
+    ValueError
+        If `which` is not one of ['y', 'x', 'both']
+
+    Examples
+    --------
+
+    Set colorbar yaxis ticks to scientific
+
+    .. plot::
+        :context: close-figs
+
+        >>> import seaborn_image as isns
+        >>> img = isns.load_image("polymer") * 1e-9
+        >>> f, ax, cax = isns.imgplot(img)
+        >>> isns.scientific_ticks(cax)
+
+    Set colorbar xaxis ticks to scientific
+
+    .. plot::
+        :context: close-figs
+
+        >>> import seaborn_image as isns
+        >>> img = isns.load_image("polymer") * 1e-9
+        >>> f, ax, cax = isns.imgplot(img, orientation="h")
+        >>> isns.scientific_ticks(cax, which="x")
+    """
+
     formatter = ticker.ScalarFormatter(useMathText=True)
     formatter.set_scientific(True)
     # formatter.set_powerlimits((-1,1))
-    ax.yaxis.set_major_formatter(formatter)
+
+    if which == "both":
+        ax.yaxis.set_major_formatter(formatter)
+        ax.xaxis.set_major_formatter(formatter)
+    elif which == "y":
+        ax.yaxis.set_major_formatter(formatter)
+    elif which == "x":
+        ax.xaxis.set_major_formatter(formatter)
+    else:
+        raise ValueError("Options include: 'both', 'y', 'x'")
 
 
 def despine(fig=None, ax=None, which="all"):
+    """Remove the specified spine/s from a given
+    `matplotlib.Axes` or all the axes from a given
+    `matplotlib.Figure`.
+
+    Parameters
+    ----------
+    fig : `matplotlib.figure.Figure`, optional
+        The figure where all the axes are to be despined, by default None
+    ax : `matplotlib.axes.Axes`, optional
+        The axes to despine, by default None
+    which : str or list, optional
+        The specific spine to remove, by default "all"
+
+    Raises
+    ------
+    ValueError
+        If the `which` is not in the list of spines :
+        ["all", "top", "bottom", "right", "left"]
+    TypeError
+        If `which` is not a str or list
+
+    Examples
+    --------
+
+    Despine all axes in a figure
+
+    .. plot::
+        :context: close-figs
+
+        >>> import seaborn_image as isns
+        >>> fig, axes = plt.subplots(nrows=2, ncols=3)
+        >>> isns.despine()
+
+    Or equivalently
+
+    .. plot::
+        :context: close-figs
+
+        >>> import seaborn_image as isns
+        >>> fig, axes = plt.subplots(nrows=2, ncols=3)
+        >>> isns.despine(fig)
+
+    Despine a specific axis
+
+    .. plot::
+        :context: close-figs
+
+        >>> import seaborn_image as isns
+        >>> fig, axes = plt.subplots(nrows=2, ncols=3)
+        >>> isns.despine(ax=axes[-1][-1])
+
+    Despine only top and right axes
+
+    .. plot::
+        :context: close-figs
+
+        >>> import seaborn_image as isns
+        >>> fig, axes = plt.subplots(nrows=2, ncols=3)
+        >>> isns.despine(which=["top", "right"])
+    """
+
     if fig is None and ax is None:
         axes = plt.gcf().axes
     elif fig is not None:
         axes = fig.axes
     elif ax is not None:
-        axes = [ax]
+        if isinstance(ax, np.ndarray):
+            axes = ax.ravel()
+        else:
+            axes = [ax]
 
     _all = ["top", "bottom", "right", "left"]
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -114,4 +114,11 @@ def test_rc_assertion():
 
 def test_reset_defaults():
     isns.reset_defaults()
-    assert mpl.rcParams == mpl.rcParamsDefault
+
+    for k, v in mpl.rcParams.items():
+        # ignore scalebar keys since they are not in
+        # matplotlib defaults
+        if "scalebar" in k:
+            pass
+        else:
+            assert mpl.rcParams[k] == mpl.rcParamsDefault[k]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -110,3 +110,8 @@ def test_rc_assertion():
 
         rc = ["color", "black"]
         isns.set_scalebar(rc=rc)
+
+
+def test_reset_defaults():
+    isns.reset_defaults()
+    assert mpl.rcParams == mpl.rcParamsDefault

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,12 +22,6 @@ def test_setup_figure():
     assert isinstance(ax, Axes)
 
 
-def test_setup_figure_check_title_dict():
-    with pytest.raises(TypeError):
-        img_setup = isns._core._SetupImage(data, title_dict=[{"fontsize": 20}])
-        f, ax = img_setup._setup_figure()
-
-
 def test_setup_scalebar():
     with pytest.raises(AttributeError):
         img_setup = isns._core._SetupImage(data, dx=1)
@@ -47,14 +41,6 @@ def test_setup_scalebar_dimension():
 def test_cbar_orientation():
     with pytest.raises(ValueError):
         img_setup = isns._core._SetupImage(data, cbar=True, orientation="right")
-        f, ax, cax = img_setup.plot()
-
-
-def test_plot_check_cbar_dict():
-    with pytest.raises(TypeError):
-        img_setup = isns._core._SetupImage(
-            data, cbar=True, cbar_fontdict=[{"fontsize": 20}]
-        )
         f, ax, cax = img_setup.plot()
 
 
@@ -127,14 +113,11 @@ def test_plot_w_all_inputs(
         vmax=None,
         robust=robust,
         perc=(2, 98),
-        title="My Title",
-        fontdict={"fontsize": 20},
         dx=dx,
         units=units,
         dimension=dimension,
         cbar=cbar,
         orientation=orientation,
-        cbar_fontdict={"fontsize": 20},
         cbar_label="cbar label",
         cbar_ticks=[],
         showticks=showticks,

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -57,11 +57,6 @@ def test_cbar_label_type():
         isns.imgplot(data, cbar_label=["Title"])
 
 
-def test_cbar_fontdict_type():
-    with pytest.raises(TypeError):
-        isns.imgplot(data, cbar_fontdict=["fontsize", 20])
-
-
 def test_showticks_type():
     with pytest.raises(TypeError):
         isns.imgplot(data, showticks="True")
@@ -70,16 +65,6 @@ def test_showticks_type():
 def test_despine_type():
     with pytest.raises(TypeError):
         isns.imgplot(data, despine="True")
-
-
-def test_title_type():
-    with pytest.raises(TypeError):
-        isns.imgplot(data, title=["Title"])
-
-
-def test_title_fontdict_type():
-    with pytest.raises(TypeError):
-        isns.imgplot(data, title_fontdict=[{"fontsize": 20}])
 
 
 @pytest.mark.parametrize("data", [data, astronaut()])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -58,3 +58,27 @@ def test_load_image():
 def test_load_image_error():
     with pytest.raises(ValueError):
         isns.load_image("coins")
+
+
+def test_scientific_ticks():
+    img = isns.load_image("polymer") * 1e-9
+
+    f, ax, cax = isns.imgplot(img)
+    isns.scientific_ticks(cax, which="y")
+    plt.close()
+
+    f, ax, cax = isns.imgplot(img, orientation="h")
+    isns.scientific_ticks(cax, which="x")
+    plt.close()
+
+    f, ax, cax = isns.imgplot(img)
+    isns.scientific_ticks(cax, which="both")
+    plt.close()
+
+
+def test_scientific_ticks_valueerror():
+    with pytest.raises(ValueError):
+        img = isns.load_image("polymer") * 1e-9
+        f, ax, cax = isns.imgplot(img)
+        isns.scientific_ticks(cax, which="all")
+        plt.close()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,7 @@ _all = ["top", "bottom", "right", "left"]
     "fig_to_despine", [plt.subplots(), plt.subplots(nrows=2, ncols=3)]
 )
 @pytest.mark.parametrize("fig", [None, plt.gcf()])  # test when fig is None and not None
-def test_despine(fig_to_despine, fig, which):
+def test_despine(fig_to_despine, fig, which):  # TODO improve this test
     f, ax = fig_to_despine
 
     if which == "all":
@@ -31,6 +31,10 @@ def test_despine(fig_to_despine, fig, which):
     else:
         isns.despine(fig=fig, which=which)
         # assert ax.spines[which] == False
+
+    # test axes despine when ndarray
+    f, ax = fig_to_despine
+    isns.despine(ax=ax)
 
     plt.close("all")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,8 +14,12 @@ _all = ["top", "bottom", "right", "left"]
 @pytest.mark.parametrize(
     "which", ["all", "top", "bottom", "right", "left", ["top", "right"], _all]
 )
-def test_despine(which):
-    f, ax = plt.subplots()
+@pytest.mark.parametrize(
+    "fig_to_despine", [plt.subplots(), plt.subplots(nrows=2, ncols=3)]
+)
+@pytest.mark.parametrize("fig", [None, plt.gcf()])  # test when fig is None and not None
+def test_despine(fig_to_despine, fig, which):
+    f, ax = fig_to_despine
 
     if which == "all":
         which = _all
@@ -25,7 +29,7 @@ def test_despine(which):
             isns.despine(which=side)
             # assert ax.spines[side] == False
     else:
-        isns.despine(which=which)
+        isns.despine(fig=fig, which=which)
         # assert ax.spines[which] == False
 
     plt.close("all")


### PR DESCRIPTION
# Clean up function kwargs
The following have been removed from `imgplot` as well as other visualizations functions:
- `cbar_dict`
- `title`
- `title_dict`

The rationale is that if the user wants to set title for example, they can just do `ax.set_title("Title")`. There is no real need to provide this as kwarg in `seaborn_image` functions. It was anyways remnant of some old code.


# Docstring reformat to numpy style and use plot-directive in examples
- [x]  imgplot
- [x]  imghist
- [x] filterplot
<s>fftplot</s> This will be done with the `fftplot` enhancement
- [x] FilterGrid
- [x] context 
- [x] utils