### PR TITLE
Stricter separation between axes and fig level functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,23 +9,23 @@
 
 <div class="row">
 
-  <a href="https://seaborn-image.readthedocs.io/auto_examples/plot_image_hist.html">
+  <a href="https://seaborn-image.readthedocs.io/en/latest/auto_examples/plot_image_hist.html">
   <img src="./images/sphx_glr_plot_image_hist_001.png" height="120" width="170">
   </a>
 
-  <a href="https://seaborn-image.readthedocs.io/auto_examples/plot_filter.html">
+  <a href="https://seaborn-image.readthedocs.io/en/latest/auto_examples/plot_filter.html">
   <img src="./images/sphx_glr_plot_filter_001.png" height="120" width="130">
   </a>
 
-  <a href="https://seaborn-image.readthedocs.io/auto_examples/plot_fft.html">
+  <a href="https://seaborn-image.readthedocs.io/en/latest/auto_examples/plot_fft.html">
   <img src="./images/sphx_glr_plot_fft_001.png" height="120" width="120">
   </a>
 
-  <a href="https://seaborn-image.readthedocs.io/auto_examples/plot_filtergrid.html">
+  <a href="https://seaborn-image.readthedocs.io/en/latest/auto_examples/plot_filtergrid.html">
   <img src="./images/sphx_glr_plot_filtergrid_001.png" height="120" width="120">
   </a>
 
-  <a href="https://seaborn-image.readthedocs.io/auto_examples/plot_image_robust.html">
+  <a href="https://seaborn-image.readthedocs.io/en/latest/auto_examples/plot_image_robust.html">
   <img src="./images/sphx_glr_plot_image_robust_001.png" height="120" width="260">
   </a>
 

--- a/src/seaborn_image/_filters.py
+++ b/src/seaborn_image/_filters.py
@@ -118,20 +118,17 @@ def filterplot(
 
     Returns
     -------
-        (tuple): tuple containing:
-
-            (`matplotlib.axes.Axes`): Matplotlib axes where the image is drawn.
-            (`matplotlib.axes.Axes`): Colorbar axes
-            (`numpy.array`): Filtered image data
+    `matplotlib.axes.Axes`
+        Matplotlib axes where the image is drawn.
 
     Raises
     ------
-        TypeError
-            if `filt` is not a string type or callable function
-        NotImplementedError
-            if a `filt` that is not implemented is specified
-        TypeError
-            if `describe` is not a `bool`
+    TypeError
+        if `filt` is not a string type or callable function
+    NotImplementedError
+        if a `filt` that is not implemented is specified
+    TypeError
+        if `describe` is not a `bool`
 
     Examples
     --------
@@ -193,7 +190,7 @@ def filterplot(
         filtered_data = filt_func(data, **func_kwargs)
 
     # finally, plot the filtered image
-    f, ax, cax = imgplot(
+    ax = imgplot(
         filtered_data,
         ax=ax,
         cmap=cmap,
@@ -224,7 +221,7 @@ def filterplot(
         print(f"Variance : {result_1.variance}")
         print(f"Skewness : {result_1.skewness}")
 
-    return ax, cax, filtered_data
+    return ax
 
 
 def fftplot(
@@ -250,7 +247,7 @@ def fftplot(
     # perform fft
     data_f_mag = fftshift(np.abs(fftn(w_data)))
 
-    f, ax, cax = imgplot(
+    ax = imgplot(
         np.log(data_f_mag),
         ax=ax,
         cmap=cmap,
@@ -261,4 +258,4 @@ def fftplot(
         despine=despine,
     )
 
-    return ax, cax
+    return ax

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -94,12 +94,8 @@ def imgplot(
 
     Returns
     -------
-    `matplotlib.figure.Figure`
-        Matplotlib figure.
     `matplotlib.axes.Axes`
         Matplotlib axes where the image is drawn.
-    `matplotlib.axes.Axes`
-        Colorbar axes
 
     Raises
     ------
@@ -279,10 +275,10 @@ def imgplot(
         print(f"Variance : {result.variance}")
         print(f"Skewness : {result.skewness}")
 
-    return f, ax, cax
+    return ax
 
 
-# TODO implement a imgdist function with more distributions
+# TODO implement a imgdist function with more distributions (?)
 # TODO add height, aspect parameter
 def imghist(
     data,
@@ -367,12 +363,6 @@ def imghist(
     -------
     `matplotlib.figure.Figure`
         Matplotlib figure.
-    `matplotlib.axes.Axes`
-        Matplotlib axes where the image is drawn.
-    `matplotlib.axes.Axes`
-        Matplotlib axes where the histogram is drawn.
-    `matplotlib.axes.Axes`
-        Colorbar axes
 
     Raises
     ------
@@ -438,7 +428,7 @@ def imghist(
 
     ax1 = f.add_subplot(gs[0])
 
-    f, ax1, cax = imgplot(
+    ax1 = imgplot(
         data,
         ax=ax1,
         cmap=cmap,
@@ -457,6 +447,9 @@ def imghist(
         showticks=showticks,
         despine=despine,
     )
+
+    # get colorbar axes
+    cax = f.axes[1]
 
     if orientation == "vertical":
         ax2 = f.add_subplot(gs[1], sharey=cax)
@@ -496,4 +489,4 @@ def imghist(
     for c, p in zip(col, patches):
         plt.setp(p, "facecolor", cm(c))
 
-    return f, (ax1, ax2), cax
+    return f

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -337,8 +337,10 @@ class FilterGrid(object):
     def _plot(self, ax, **func_kwargs):
         """Helper function to call the underlying filterplot
 
-        Args:
-            ax (`matplotlib.axes.Axes`): Axis to plot filtered image
+        Parameters
+        ----------
+        ax : `matplotlib.axes.Axes`
+            Axis to plot filtered image
         """
 
         filterplot(

--- a/src/seaborn_image/utils.py
+++ b/src/seaborn_image/utils.py
@@ -33,7 +33,9 @@ def scientific_ticks(ax, which="y"):
 
         >>> import seaborn_image as isns
         >>> img = isns.load_image("polymer") * 1e-9
-        >>> f, ax, cax = isns.imgplot(img)
+        >>> ax = isns.imgplot(img)
+        >>> # get colorbar axes
+        >>> cax = plt.gcf().axes[1]
         >>> isns.scientific_ticks(cax)
 
     Set colorbar xaxis ticks to scientific
@@ -43,7 +45,9 @@ def scientific_ticks(ax, which="y"):
 
         >>> import seaborn_image as isns
         >>> img = isns.load_image("polymer") * 1e-9
-        >>> f, ax, cax = isns.imgplot(img, orientation="h")
+        >>> ax = isns.imgplot(img, orientation="h")
+        >>> # get colorbar axes
+        >>> cax = plt.gcf().axes[1]
         >>> isns.scientific_ticks(cax, which="x")
     """
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -34,147 +34,161 @@ def test_describe_type(describe):
         isns.filterplot(data, "sobel", describe=describe)
 
 
-# @pytest.mark.parametrize("filt", isns.implemented_filters)
 @pytest.mark.parametrize("describe", [True, False])
-def test_filters(describe):
-    ax, cax, filt_data = isns.filterplot(data, "sobel", describe=describe)
+def test_filterplot_describe(describe):
+    ax = isns.filterplot(data, "sobel", describe=describe)
 
     assert isinstance(ax, Axes)
-    assert isinstance(cax, Axes)
 
     plt.close("all")
 
 
 def test_filterplot_callable_filt():
     "Test a callable filt parameter with additional parameters passed to the callable filt function"
-    _, _, filt_data = isns.filterplot(data, ndi.uniform_filter, size=5, mode="nearest")
+    ax = isns.filterplot(data, ndi.uniform_filter, size=5, mode="nearest")
 
     np.testing.assert_array_equal(
-        filt_data, ndi.uniform_filter(data, size=5, mode="nearest")
+        ax.images[0].get_array().data, ndi.uniform_filter(data, size=5, mode="nearest")
     )
 
     plt.close("all")
 
 
 def test_filterplot_gaussian():
-    _, _, filt_data = isns.filterplot(data, filt="gaussian", sigma=1)
+    ax = isns.filterplot(data, filt="gaussian", sigma=1)
 
-    np.testing.assert_array_equal(filt_data, ndi.gaussian_filter(data, sigma=1))
+    np.testing.assert_array_equal(
+        ax.images[0].get_array().data, ndi.gaussian_filter(data, sigma=1)
+    )
 
     plt.close("all")
 
 
 def test_filterplot_sobel():
-    _, _, filt_data = isns.filterplot(data, filt="sobel")
+    ax = isns.filterplot(data, filt="sobel")
 
-    np.testing.assert_array_equal(filt_data, ndi.sobel(data))
+    np.testing.assert_array_equal(ax.images[0].get_array().data, ndi.sobel(data))
 
     plt.close("all")
 
 
 def test_filterplot_median():
-    _, _, filt_data = isns.filterplot(data, filt="median", size=5)
+    ax = isns.filterplot(data, filt="median", size=5)
 
-    np.testing.assert_array_equal(filt_data, ndi.median_filter(data, size=5))
+    np.testing.assert_array_equal(
+        ax.images[0].get_array().data, ndi.median_filter(data, size=5)
+    )
 
     plt.close("all")
 
 
 def test_filterplot_max():
-    _, _, filt_data = isns.filterplot(data, filt="max", size=5)
+    ax = isns.filterplot(data, filt="max", size=5)
 
-    np.testing.assert_array_equal(filt_data, ndi.maximum_filter(data, size=5))
+    np.testing.assert_array_equal(
+        ax.images[0].get_array().data, ndi.maximum_filter(data, size=5)
+    )
 
     plt.close("all")
 
 
 def test_filterplot_diff_of_gaussian():
-    _, _, filt_data = isns.filterplot(data, filt="diff_of_gaussians", low_sigma=1)
+    ax = isns.filterplot(data, filt="diff_of_gaussians", low_sigma=1)
 
-    np.testing.assert_array_equal(filt_data, difference_of_gaussians(data, low_sigma=1))
+    np.testing.assert_array_equal(
+        ax.images[0].get_array().data, difference_of_gaussians(data, low_sigma=1)
+    )
 
     plt.close("all")
 
 
 def test_filterplot_gaussian_gradient_magnitude():
-    _, _, filt_data = isns.filterplot(data, filt="gaussian_gradient_magnitude", sigma=1)
+    ax = isns.filterplot(data, filt="gaussian_gradient_magnitude", sigma=1)
 
     np.testing.assert_array_equal(
-        filt_data, ndi.gaussian_gradient_magnitude(data, sigma=1)
+        ax.images[0].get_array().data, ndi.gaussian_gradient_magnitude(data, sigma=1)
     )
 
     plt.close("all")
 
 
 def test_filterplot_gaussian_laplace():
-    _, _, filt_data = isns.filterplot(data, filt="gaussian_laplace", sigma=1)
+    ax = isns.filterplot(data, filt="gaussian_laplace", sigma=1)
 
-    np.testing.assert_array_equal(filt_data, ndi.gaussian_laplace(data, sigma=1))
+    np.testing.assert_array_equal(
+        ax.images[0].get_array().data, ndi.gaussian_laplace(data, sigma=1)
+    )
 
     plt.close("all")
 
 
 def test_filterplot_laplace():
-    _, _, filt_data = isns.filterplot(data, filt="laplace")
+    ax = isns.filterplot(data, filt="laplace")
 
-    np.testing.assert_array_equal(filt_data, ndi.laplace(data))
+    np.testing.assert_array_equal(ax.images[0].get_array().data, ndi.laplace(data))
 
     plt.close("all")
 
 
 def test_filterplot_min():
-    _, _, filt_data = isns.filterplot(data, filt="min", size=5)
+    ax = isns.filterplot(data, filt="min", size=5)
 
-    np.testing.assert_array_equal(filt_data, ndi.minimum_filter(data, size=5))
+    np.testing.assert_array_equal(
+        ax.images[0].get_array().data, ndi.minimum_filter(data, size=5)
+    )
 
     plt.close("all")
 
 
 def test_filterplot_percentile():
-    _, _, filt_data = isns.filterplot(data, filt="percentile", percentile=10, size=10)
+    ax = isns.filterplot(data, filt="percentile", percentile=10, size=10)
 
     np.testing.assert_array_equal(
-        filt_data, ndi.percentile_filter(data, percentile=10, size=10)
+        ax.images[0].get_array().data,
+        ndi.percentile_filter(data, percentile=10, size=10),
     )
 
     plt.close("all")
 
 
 def test_filterplot_prewitt():
-    _, _, filt_data = isns.filterplot(data, filt="prewitt")
+    ax = isns.filterplot(data, filt="prewitt")
 
-    np.testing.assert_array_equal(filt_data, ndi.prewitt(data))
+    np.testing.assert_array_equal(ax.images[0].get_array().data, ndi.prewitt(data))
 
     plt.close("all")
 
 
 def test_filterplot_rank():
-    _, _, filt_data = isns.filterplot(data, filt="rank", rank=1, size=10)
+    ax = isns.filterplot(data, filt="rank", rank=1, size=10)
 
-    np.testing.assert_array_equal(filt_data, ndi.rank_filter(data, rank=1, size=10))
+    np.testing.assert_array_equal(
+        ax.images[0].get_array().data, ndi.rank_filter(data, rank=1, size=10)
+    )
 
     plt.close("all")
 
 
 def test_filterplot_uniform():
-    _, _, filt_data = isns.filterplot(data, filt="uniform")
+    ax = isns.filterplot(data, filt="uniform")
 
-    np.testing.assert_array_equal(filt_data, ndi.uniform_filter(data))
+    np.testing.assert_array_equal(
+        ax.images[0].get_array().data, ndi.uniform_filter(data)
+    )
 
     plt.close("all")
 
 
 def test_fftplot_plot():
-    ax, cax = isns.fftplot(data)
+    ax = isns.fftplot(data)
 
     assert isinstance(ax, Axes)
-    assert isinstance(cax, Axes)
 
     plt.close("all")
 
 
 def test_fftplot_fft():
-    ax, cax = isns.fftplot(data)
+    ax = isns.fftplot(data)
 
     w_data = data * window("hann", data.shape)
     data_f_mag = fftshift(np.abs(fftn(w_data)))

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -69,23 +69,24 @@ def test_despine_type():
 
 @pytest.mark.parametrize("data", [data, astronaut()])
 def test_imgplot_return(data):
-    f, ax, cax = isns.imgplot(data)
+    ax = isns.imgplot(data)
 
-    assert isinstance(f, Figure)
+    f = plt.gcf()
+
     assert isinstance(ax, Axes)
     if (
         data.ndim == 3
     ):  # if data dim is 3 it cbar will be set to False, and cax will be None
-        assert cax is None
+        pass  # no colorbar axes in this case
     else:
-        assert isinstance(cax, Axes)
+        assert isinstance(f.axes[1], Axes)
 
     plt.close("all")
 
 
 @pytest.mark.parametrize("data", [data, astronaut()])
 def test_imgplot_data_is_same_as_input(data):
-    f, ax, cax = isns.imgplot(data)
+    ax = isns.imgplot(data)
 
     # check if data iput is what was plotted
     np.testing.assert_array_equal(ax.images[0].get_array().data, data)
@@ -95,7 +96,7 @@ def test_imgplot_gray_conversion_for_rgb():
     """Check if the plotted data is grayscale when input is RGB image
     and gray is True.
     """
-    f, ax, cax = isns.imgplot(astronaut(), gray=True)
+    ax = isns.imgplot(astronaut(), gray=True)
 
     np.testing.assert_array_equal(ax.images[0].get_array().data, rgb2gray(astronaut()))
 
@@ -104,13 +105,13 @@ def test_imgplot_gray_conversion_for_rgb():
 @pytest.mark.parametrize("cmap", [None, "ice"])
 @pytest.mark.parametrize("data", [data, astronaut()])
 def test_gray_cmap_interplay(data, gray, cmap):
-    f, ax, cax = isns.imgplot(data, cmap=cmap, gray=gray)
+    _ = isns.imgplot(data, cmap=cmap, gray=gray)
     plt.close("all")
 
 
 @pytest.mark.parametrize("describe", [True, False])
 def test_imgplot_w_describe(describe):
-    f, ax, cax = isns.imgplot(data, describe=describe)
+    _ = isns.imgplot(data, describe=describe)
     plt.close("all")
 
 
@@ -132,21 +133,21 @@ def test_imghist_orientation_value():
 
 
 def test_imghist_return():
-    f, axes, cax = isns.imghist(data)
+    f = isns.imghist(data)
 
     assert isinstance(f, Figure)
-    assert isinstance(axes[0], Axes)
-    assert isinstance(axes[1], Axes)
-    assert isinstance(cax, Axes)
+    assert isinstance(f.axes[0], Axes)
+    assert isinstance(f.axes[1], Axes)
+    assert isinstance(f.axes[2], Axes)
 
     plt.close("all")
 
 
 def test_imghist_data_is_same_as_input():
-    f, ax, cax = isns.imghist(data)
+    f = isns.imghist(data)
 
     # check if data iput is what was plotted
-    np.testing.assert_array_equal(ax[0].images[0].get_array().data, data)
+    np.testing.assert_array_equal(f.axes[0].images[0].get_array().data, data)
 
 
 @pytest.mark.parametrize("cmap", [None, "acton"])
@@ -161,7 +162,7 @@ def test_imghist_w_all_valid_inputs(
     showticks,
     despine,
 ):
-    f, axes, cax = isns.imghist(
+    _ = isns.imghist(
         data,
         cmap=cmap,
         bins=bins,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -71,15 +71,18 @@ def test_load_image_error():
 def test_scientific_ticks():
     img = isns.load_image("polymer") * 1e-9
 
-    f, ax, cax = isns.imgplot(img)
+    _ = isns.imgplot(img)
+    cax = plt.gcf().axes[1]
     isns.scientific_ticks(cax, which="y")
     plt.close()
 
-    f, ax, cax = isns.imgplot(img, orientation="h")
+    _ = isns.imgplot(img, orientation="h")
+    cax = plt.gcf().axes[1]
     isns.scientific_ticks(cax, which="x")
     plt.close()
 
-    f, ax, cax = isns.imgplot(img)
+    _ = isns.imgplot(img)
+    cax = plt.gcf().axes[1]
     isns.scientific_ticks(cax, which="both")
     plt.close()
 
@@ -87,6 +90,7 @@ def test_scientific_ticks():
 def test_scientific_ticks_valueerror():
     with pytest.raises(ValueError):
         img = isns.load_image("polymer") * 1e-9
-        f, ax, cax = isns.imgplot(img)
+        _ = isns.imgplot(img)
+        cax = plt.gcf().axes[1]
         isns.scientific_ticks(cax, which="all")
         plt.close()


### PR DESCRIPTION
## Stricter separation between `axes` level and `figure` level functions

| Axes level | Figure level |
| --- | ----------- |
| `imgplot()` | `imghist()` |
| `filterplot()` | `FilterGrid()` |
| `fftplot()` |  |

Axes level functions only return `matplotlib.axes.Axes` and figure level functions only return `matplotlib.figure.Figure` or `seaborn_image.FilterGrid`.