### PR TITLE
Add `height` and `aspect` parameters to `imghist()`

### DIFF
--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -279,7 +279,6 @@ def imgplot(
 
 
 # TODO implement a imgdist function with more distributions (?)
-# TODO add height, aspect parameter
 def imghist(
     data,
     cmap=None,
@@ -475,7 +474,6 @@ def imghist(
         ax2.get_xaxis().set_visible(False)
         ax2.get_yaxis().set_visible(False)
 
-    # if despine:
     ax2.set_frame_on(False)
 
     if cmap is None:

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -386,12 +386,26 @@ def imghist(
         >>> img = isns.load_image("polymer")
         >>> isns.imghist(img)
 
+    Change the orientation
+
+    .. plot::
+        :context: close-figs
+
+        >>> isns.imghist(img, orientation="h")
+
     Change the number of bins
 
     .. plot::
         :context: close-figs
 
         >>> isns.imghist(img, bins=300)
+
+    Change height and aspect ratio of the figure
+
+    .. plot::
+        :context: close-figs
+
+        >>> isns.imghist(img, height=4, aspect=1.5)
 
     Add a scalebar
 
@@ -405,7 +419,7 @@ def imghist(
     .. plot::
         :context: close-figs
 
-        >>> isns.imghist(img, cmap="deep")
+        >>> isns.imghist(img, cmap="ice")
     """
 
     if bins is None:

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -298,6 +298,8 @@ def imghist(
     cbar_ticks=None,
     showticks=False,
     despine=True,
+    height=5,
+    aspect=1.75,
 ):
     """Plot data as a 2-D image with histogram showing the distribution of
     the data. Options to add scalebar, colorbar, title.
@@ -358,6 +360,10 @@ def imghist(
         Show image x-y axis ticks, by default False
     despine : bool, optional
         Remove axes spines from image axes as well as colorbar axes, by default True
+    height : int or float, optional
+        Size of the individual images, by default 5.
+    aspect : int or float, optional
+        Aspect ratio of individual images, by default 1.75.
 
     Returns
     -------
@@ -413,13 +419,13 @@ def imghist(
 
     if orientation in ["v", "vertical"]:
         orientation = "vertical"  # matplotlib doesn't support 'v'
-        f = plt.figure(figsize=(10, 6))  # TODO make figsize user defined
-        gs = gridspec.GridSpec(1, 2, width_ratios=[5, 1], figure=f)
+        f = plt.figure(figsize=(height * aspect, height))
+        gs = gridspec.GridSpec(1, 2, width_ratios=[height - 1, 1], figure=f)
 
     elif orientation in ["h", "horizontal"]:
         orientation = "horizontal"  # matplotlib doesn't support 'h'
-        f = plt.figure(figsize=(6, 10))  # TODO make figsize user defined
-        gs = gridspec.GridSpec(2, 1, height_ratios=[5, 1], figure=f)
+        f = plt.figure(figsize=(height, height * aspect))
+        gs = gridspec.GridSpec(2, 1, height_ratios=[height - 1, 1], figure=f)
 
     else:
         raise ValueError(

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -36,9 +36,9 @@ class FilterGrid(object):
     col_wrap : int, optional
         Number of columns to display if `col`
         is not None and `row` is None. Defaults to None.
-    height : int, optional
+    height : int or float, optional
         Size of the individual images. Defaults to 3.
-    aspect : int, optional
+    aspect : int or float, optional
         Aspect ratio of individual images. Defaults to 1.
     cmap : str or `matplotlib.colors.Colormap`, optional
         Image colormap. Defaults to None.

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -143,6 +143,18 @@ def test_imghist_return():
     plt.close("all")
 
 
+def test_imghist_figsize():
+    # check default
+    f = isns.imghist(data)
+    np.testing.assert_array_equal(f.get_size_inches(), (5 * 1.75, 5))
+    plt.close()
+
+    # check user specified
+    f = isns.imghist(data, height=6, aspect=1.5)
+    np.testing.assert_array_equal(f.get_size_inches(), (6 * 1.5, 6))
+    plt.close()
+
+
 def test_imghist_data_is_same_as_input():
     f = isns.imghist(data)
 


### PR DESCRIPTION
Height and aspect ratio can now be controlled for `imghist()` function

Example:
```python
isns.imghist(img, height=4, aspect=1.5)
```