### PR TITLE
`rgbplot()`, as a special case of `ImageGrid()`

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -25,6 +25,12 @@ ImageGrid
    :members:
 
 
+rgbplot
+-------
+
+.. autofunction:: seaborn_image.rgbplot
+
+
 filterplot
 ----------
 

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -13,8 +13,6 @@ from ._core import _SetupImage
 __all__ = ["imgplot", "imghist"]
 
 
-# TODO implement rgbplot() - which has options
-# to split the channels
 def imgplot(
     data,
     ax=None,

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -510,7 +510,7 @@ def rgbplot(
 
     # if no cmap, assign reds, greens and blues cmap
     if cmap is None:
-        cmap = ["Reds_r", "Greens_r", "Blues_r"]
+        cmap = ["Reds", "Greens", "Blues"]
 
     # split RGB channels
     _d = [data[:, :, 0], data[:, :, 1], data[:, :, 2]]

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -396,12 +396,13 @@ def rgbplot(
     showticks=False,
     despine=True,
 ):
-    """[summary]
+    """Split and plot the red, green and blue channels of an
+    RGB image.
 
     Parameters
     ----------
-    data : [type]
-        [description]
+    data :
+        RGB image data as 3-D array.
     col_wrap : int, optional
         Number of columns to display. Defaults to 3.
     height : int or float, optional

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -9,7 +9,7 @@ from ._filters import filterplot
 from ._general import imgplot
 from .utils import despine
 
-__all__ = ["FilterGrid", "ImageGrid"]
+__all__ = ["FilterGrid", "ImageGrid", "rgbplot"]
 
 
 class ImageGrid:
@@ -377,6 +377,161 @@ class ImageGrid:
                 rem_ax[i].set_xlabel("")
 
                 despine(ax=rem_ax[i])  # remove axes spines for the extra generated axes
+
+
+def rgbplot(
+    data,
+    *,
+    col_wrap=3,
+    height=3,
+    aspect=1,
+    cmap=None,
+    dx=None,
+    units=None,
+    dimension=None,
+    cbar=True,
+    orientation="v",
+    cbar_label=None,
+    cbar_ticks=None,
+    showticks=False,
+    despine=True,
+):
+    """[summary]
+
+    Parameters
+    ----------
+    data : [type]
+        [description]
+    col_wrap : int, optional
+        Number of columns to display. Defaults to 3.
+    height : int or float, optional
+        Size of the individual images. Defaults to 3.
+    aspect : int or float, optional
+        Aspect ratio of individual images. Defaults to 1.
+    cmap : str or `matplotlib.colors.Colormap` or list, optional
+        Image colormap or a list of colormaps. Defaults to None.
+    dx : float or list, optional
+        Size per pixel of the image data. If scalebar
+        is required, `dx` and `units` must be sepcified.
+        Can be a list of floats.
+        Defaults to None.
+    units : str or list, optional
+        Units of `dx`.
+        Can be a list of str.
+        Defaults to None.
+    dimension : str or list, optional
+        Dimension of `dx` and `units`.
+        Options include :
+            - "si" : scale bar showing km, m, cm, etc.
+            - "imperial" : scale bar showing in, ft, yd, mi, etc.
+            - "si-reciprocal" : scale bar showing 1/m, 1/cm, etc.
+            - "angle" : scale bar showing °, ʹ (minute of arc) or ʹʹ (second of arc).
+            - "pixel" : scale bar showing px, kpx, Mpx, etc.
+        Can be a list of str.
+        Defaults to None.
+    cbar : bool or list, optional
+        Specify if a colorbar is required or not.
+        Can be a list of bools.
+        Defaults to True.
+    orientation : str, optional
+        Specify the orientaion of colorbar.
+        Option include :
+            - 'h' or 'horizontal' for a horizontal colorbar to the bottom of the image.
+            - 'v' or 'vertical' for a vertical colorbar to the right of the image.
+        Defaults to 'v'.
+    cbar_label : str or list, optional
+        Colorbar label.
+        Can be a list of str.
+        Defaults to None.
+    cbar_ticks : list, optional
+        List of colorbar ticks. Defaults to None.
+    showticks : bool, optional
+        Show image x-y axis ticks. Defaults to False.
+    despine : bool, optional
+        Remove axes spines from image axes as well as colorbar axes.
+        Defaults to True.
+
+    Returns
+    -------
+    `seaborn_image.ImageGrid`
+
+    Raises
+    ------
+    ValueError
+        If `data` dimension is not 3
+    ValueError
+        If `data` channels are not 3
+
+    Examples
+    --------
+
+    Split and plot the channels of a RGB image
+
+    .. plot::
+        :context: close-figs
+
+        >>> import seaborn_image as isns; isns.set_image(origin="upper")
+        >>> from skimage.data import astronaut
+        >>> g = isns.rgbplot(astronaut())
+
+    Hide colorbar
+
+    .. plot::
+        :context: close-figs
+
+        >>> g = isns.rgbplot(astronaut(), cbar=False)
+
+    Change colormap
+
+    .. plot::
+        :context: close-figs
+
+        >>> g = isns.rgbplot(astronaut(), cmap="deep")
+
+    .. plot::
+        :context: close-figs
+
+        >>> g = isns.rgbplot(astronaut(), cmap=["inferno", "viridis", "ice"])
+
+    Horizontal colorbar
+
+    .. plot::
+        :context: close-figs
+
+        >>> g = isns.rgbplot(astronaut(), orientation="h")
+    """
+
+    if not data.ndim == 3:
+        raise ValueError("imput image must be a RGB image")
+
+    if data.shape[-1] != 3:
+        raise ValueError("input image must be a RGB image")
+
+    # if no cmap, assign reds, greens and blues cmap
+    if cmap is None:
+        cmap = ["Reds_r", "Greens_r", "Blues_r"]
+
+    # split RGB channels
+    _d = [data[:, :, 0], data[:, :, 1], data[:, :, 2]]
+
+    g = ImageGrid(
+        _d,
+        height=height,
+        aspect=aspect,
+        col_wrap=col_wrap,
+        cmap=cmap,
+        dx=dx,
+        units=units,
+        dimension=dimension,
+        cbar=cbar,
+        orientation=orientation,
+        cbar_label=cbar_label,
+        cbar_ticks=cbar_ticks,
+        showticks=showticks,
+        despine=despine,
+    )
+
+    return g
 
 
 # TODO provide common cbar option

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -5,6 +5,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
+from skimage.data import astronaut
 
 import seaborn_image as isns
 
@@ -219,6 +220,28 @@ class TestImageGrid:
         )
         np.testing.assert_array_equal(g4.fig.get_size_inches(), (3 * 2 * 1.5, 2 * 2))
         plt.close()
+
+
+@pytest.mark.parametrize(
+    "img",
+    [
+        np.random.random(2500).reshape((50, 50)),
+        np.random.random(50 * 50 * 4).reshape((50, 50, 4)),
+    ],
+)
+def test_rgbplot_data(img):
+    with pytest.raises(ValueError):
+        isns.rgbplot(img)
+
+
+def test_rgbplot_cmap():
+    g = isns.rgbplot(astronaut())
+    g.cmap = ["Reds_r", "Greens_r", "Blues_r"]
+    plt.close()
+
+    g = isns.rgbplot(astronaut(), cmap=["inferno", "viridis", "ice"])
+    g.cmap = ["inferno", "viridis", "ice"]
+    plt.close()
 
 
 class TestFilterGrid(object):

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -236,7 +236,7 @@ def test_rgbplot_data(img):
 
 def test_rgbplot_cmap():
     g = isns.rgbplot(astronaut())
-    g.cmap = ["Reds_r", "Greens_r", "Blues_r"]
+    g.cmap = ["Reds", "Greens", "Blues"]
     plt.close()
 
     g = isns.rgbplot(astronaut(), cmap=["inferno", "viridis", "ice"])


### PR DESCRIPTION
This PR adds a new function `rgbplot()` which splits and plots the red, green and blue channels of an RGB image. The function returns a `seaborn_image.ImageGrid` object and is a special case of the same.

This can be done as simply as : 

```python
g = rgbplot(img)

# set specific colormaps
g = rgbplot(img, cmap=["inferno", "viridis", "ice"])
```