### PR TITLE
despine/respine globally using `despine` parameter in `set_image()`

### DIFF
--- a/examples/plot_fft.py
+++ b/examples/plot_fft.py
@@ -7,4 +7,4 @@ import seaborn_image as isns
 
 img = isns.load_image("polymer")
 
-_ = isns.fftplot(img, cmap="viridis", cbar=False, despine=False)
+_ = isns.fftplot(img, cmap="viridis")

--- a/examples/plot_filter.py
+++ b/examples/plot_filter.py
@@ -7,4 +7,4 @@ import seaborn_image as isns
 
 img = isns.load_image("polymer")
 
-_ = isns.filterplot(img, "median", size=5, cmap="ice", despine=False)
+_ = isns.filterplot(img, "median", size=5, cmap="ice")

--- a/examples/plot_filtergrid.py
+++ b/examples/plot_filtergrid.py
@@ -14,6 +14,5 @@ g = isns.FilterGrid(
     col="mode",
     sigma=[2, 3, 4],
     mode=["reflect", "nearest", "mirror"],
-    despine=False,
     cmap="magma",
 )

--- a/examples/plot_image.py
+++ b/examples/plot_image.py
@@ -9,4 +9,4 @@ import seaborn_image as isns
 img = isns.load_image("polymer")
 img_scale = {"dx": 15, "units": "nm"}
 
-_ = isns.imgplot(img, dx=15, units="nm", despine=False)
+_ = isns.imgplot(img, dx=15, units="nm")

--- a/examples/plot_image_hist.py
+++ b/examples/plot_image_hist.py
@@ -7,4 +7,4 @@ import seaborn_image as isns
 
 img = isns.load_image("polymer")
 
-_ = isns.imghist(img, cmap="YlGnBu_r", dx=15, units="nm", despine=False)
+_ = isns.imghist(img, cmap="YlGnBu_r", dx=15, units="nm")

--- a/examples/plot_image_robust.py
+++ b/examples/plot_image_robust.py
@@ -13,5 +13,5 @@ f, axes = plt.subplots(1, 2)
 
 _ = isns.imgplot(img, ax=axes[0], cmap="inferno", despine=False)
 _ = isns.imgplot(
-    img, ax=axes[1], robust=True, perc=(2, 99.99), cmap="inferno", despine=False
+    img, ax=axes[1], robust=True, perc=(2, 99.99), cmap="inferno"
 )

--- a/examples/plot_image_robust.py
+++ b/examples/plot_image_robust.py
@@ -12,6 +12,4 @@ img = isns.load_image("polymer outliers")
 f, axes = plt.subplots(1, 2)
 
 _ = isns.imgplot(img, ax=axes[0], cmap="inferno", despine=False)
-_ = isns.imgplot(
-    img, ax=axes[1], robust=True, perc=(2, 99.99), cmap="inferno"
-)
+_ = isns.imgplot(img, ax=axes[1], robust=True, perc=(2, 99.99), cmap="inferno")

--- a/src/seaborn_image/_context.py
+++ b/src/seaborn_image/_context.py
@@ -98,7 +98,7 @@ def reset_defaults():
     mpl.rcParams.update(mpl.rcParamsDefault)
 
 
-def set_image(cmap="deep", origin="lower", interpolation="nearest"):
+def set_image(cmap="deep", origin="lower", interpolation="nearest", despine=False):
     """
     Set deaults for plotting images
 
@@ -110,17 +110,33 @@ def set_image(cmap="deep", origin="lower", interpolation="nearest"):
         Image origin - same as in `matplotlib.pyplot.imshow`, by default "lower".
     interpolation : str, optional
         Image interpolation - same as in `matplotlib.pyplot.imshow`, by default "nearest".
+    despine : bool, optional
+        Despine image and colorbar axes, by default False.
 
     Examples
     --------
         >>> import seaborn_image as isns
         >>> isns.set_image(cmap="inferno", interpolation="bicubic")
+        >>> isns.set_image(despine=False)
 
     """
 
     if cmap in _CMAP_QUAL.keys():  # doesn't work currently
         cmap_mpl = _CMAP_QUAL.get(cmap).mpl_colormap
         register_cmap(name=cmap, cmap=cmap_mpl)
+
+    # change the axes spines
+    # "not" is required because of the despine parameter name
+    # if depine is True ---> you don't want the axes spines
+    # and therfore, axes.spines.bottom == False (or not True)
+    mpl.rcParams.update(
+        {
+            "axes.spines.bottom": not despine,
+            "axes.spines.left": not despine,
+            "axes.spines.right": not despine,
+            "axes.spines.top": not despine,
+        }
+    )
 
     plt.rc("image", cmap=cmap, origin=origin, interpolation=interpolation)
 

--- a/src/seaborn_image/_core.py
+++ b/src/seaborn_image/_core.py
@@ -189,7 +189,9 @@ class _SetupImage(object):
             if self.despine is True:
                 cb.outline.set_visible(False)  # remove colorbar outline border
             else:
-                self.despine = False
+                self.despine = (
+                    False  # NOTE this is only being set inside self.cbar block
+                )
 
             # display only 3 tick marks on colorbar
             if self.orientation in ["vertical"]:
@@ -224,8 +226,16 @@ class _SetupImage(object):
             # ax.get_yaxis().set_visible(False)
             # ax.get_xaxis().set_visible(False)
 
+        # This block is for handling local despine state
+        # If the state doesn't match the global state,
+        # local despine state will be preferred
         if self.despine:
             despine(ax=ax, which="all")
+
+        elif self.despine is False:  # if despine is False
+            # TODO implement a respine function (?)
+            for spine in ["top", "bottom", "right", "left"]:
+                ax.spines[spine].set_visible(True)
 
         f.tight_layout()
 

--- a/src/seaborn_image/_core.py
+++ b/src/seaborn_image/_core.py
@@ -1,3 +1,4 @@
+import matplotlib as mpl
 import matplotlib.colors as colors
 import matplotlib.pyplot as plt
 import numpy as np
@@ -39,7 +40,7 @@ class _SetupImage(object):
         cbar_label=None,
         cbar_ticks=None,
         showticks=False,
-        despine=True,
+        despine=None,
     ):
 
         self.data = data
@@ -173,8 +174,22 @@ class _SetupImage(object):
             else:
                 cb = f.colorbar(_map, cax=cax, orientation=self.orientation)
 
-            if self.despine:
+            if self.despine is None:
+                # if depsine is None, use global settings
+                # if all image axes spines are despined, cbar should also be despined
+                if (
+                    mpl.rcParams["axes.spines.top"] == False
+                    and mpl.rcParams["axes.spines.bottom"] == False
+                    and mpl.rcParams["axes.spines.left"] == False
+                    and mpl.rcParams["axes.spines.right"] == False
+                ):
+                    self.despine = True
+                    print("Here")
+
+            if self.despine is True:
                 cb.outline.set_visible(False)  # remove colorbar outline border
+            else:
+                self.despine = False
 
             # display only 3 tick marks on colorbar
             if self.orientation in ["vertical"]:

--- a/src/seaborn_image/_filters.py
+++ b/src/seaborn_image/_filters.py
@@ -51,7 +51,7 @@ def filterplot(
     cbar_label=None,
     cbar_ticks=None,
     showticks=False,
-    despine=True,
+    despine=None,
     **kwargs,
 ):
     """
@@ -250,7 +250,7 @@ def fftplot(
     ax=None,
     cmap="viridis",
     showticks=False,
-    despine=False,
+    despine=None,
     **kwargs,
 ):
     """Perform and visualize fast fourier transform of input image.

--- a/src/seaborn_image/_filters.py
+++ b/src/seaborn_image/_filters.py
@@ -124,7 +124,7 @@ def filterplot(
     showticks : bool, optional
         Show image x-y axis ticks, by default False
     despine : bool, optional
-        Remove axes spines from image axes as well as colorbar axes, by default True
+        Remove axes spines from image axes as well as colorbar axes, by default None
     **kwargs : optional
         Any additional parameters to be passed to the specific `filt` chosen.
         For instance, "sigma" or "size" or "mode" etc.
@@ -276,7 +276,7 @@ def fftplot(
     showticks : bool, optional
         Show image x-y axis ticks, by default False
     despine : bool, optional
-        Remove axes spines from image axes, by default False
+        Remove axes spines from image axes, by default None
     **kwargs : optional
         Any additional parameters to be passed to `skimage.filters.window`.
         For more information see https://scikit-image.org/docs/stable/api/skimage.filters.html#skimage.filters.window

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -36,7 +36,7 @@ def imgplot(
     cbar_label=None,
     cbar_ticks=None,
     showticks=False,
-    despine=True,
+    despine=None,
 ):
     """Plot data as a 2-D image with options to ignore outliers, add scalebar, colorbar, title.
 
@@ -265,8 +265,9 @@ def imgplot(
     if not isinstance(showticks, bool):
         raise TypeError
 
-    if not isinstance(despine, bool):
-        raise TypeError
+    if despine is not None:
+        if not isinstance(despine, bool):
+            raise TypeError
 
     if isinstance(data, np.ndarray):
         if data.ndim == 3:
@@ -341,7 +342,7 @@ def imghist(
     cbar_label=None,
     cbar_ticks=None,
     showticks=False,
-    despine=True,
+    despine=None,
     height=5,
     aspect=1.75,
 ):

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -105,7 +105,7 @@ def imgplot(
     showticks : bool, optional
         Show image x-y axis ticks, by default False
     despine : bool, optional
-        Remove axes spines from image axes as well as colorbar axes, by default True
+        Remove axes spines from image axes as well as colorbar axes, by default None
 
     Returns
     -------
@@ -207,12 +207,12 @@ def imgplot(
 
         >>> isns.imgplot(img, cbar_label="Height (nm)")
 
-    Avoid despining image and colorbar axes
+    Despine image and colorbar
 
     .. plot::
         :context: close-figs
 
-        >>> isns.imgplot(img, despine=False)
+        >>> isns.imgplot(img, despine=True)
 
     Change colorbar and colormap to log scale
 
@@ -416,7 +416,7 @@ def imghist(
     showticks : bool, optional
         Show image x-y axis ticks, by default False
     despine : bool, optional
-        Remove axes spines from image axes as well as colorbar axes, by default True
+        Remove axes spines from image axes as well as colorbar axes, by default None
     height : int or float, optional
         Size of the individual images, by default 5.
     aspect : int or float, optional

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -217,7 +217,7 @@ class ImageGrid:
         cbar_label=None,
         cbar_ticks=None,
         showticks=False,
-        despine=True,
+        despine=None,
     ):
         if data is None:
             raise ValueError("image data can not be None")
@@ -422,7 +422,7 @@ def rgbplot(
     cbar_label=None,
     cbar_ticks=None,
     showticks=False,
-    despine=True,
+    despine=None,
 ):
     """Split and plot the red, green and blue channels of an
     RGB image.
@@ -747,7 +747,7 @@ class FilterGrid(object):
         cbar_label=None,
         cbar_ticks=None,
         showticks=False,
-        despine=True,
+        despine=None,
         **kwargs,
     ):
 

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -92,7 +92,7 @@ class ImageGrid:
         Show image x-y axis ticks. Defaults to False.
     despine : bool, optional
         Remove axes spines from image axes as well as colorbar axes.
-        Defaults to True.
+        Defaults to None.
 
     Returns
     -------
@@ -485,7 +485,7 @@ def rgbplot(
         Show image x-y axis ticks. Defaults to False.
     despine : bool, optional
         Remove axes spines from image axes as well as colorbar axes.
-        Defaults to True.
+        Defaults to None.
 
     Returns
     -------
@@ -645,7 +645,7 @@ class FilterGrid(object):
         Show image x-y axis ticks. Defaults to False.
     despine : bool, optional
         Remove axes spines from image axes as well as colorbar axes.
-        Defaults to True.
+        Defaults to None.
     **kwargs : Additional parameters as keyword arguments to be passed to the underlying filter specified.
 
      Returns

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -2,6 +2,9 @@ import pytest
 
 import matplotlib as mpl
 
+# without this, it suddenly started giving matplotlib backend issues locally
+mpl.use("AGG")
+
 import seaborn_image as isns
 
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -44,6 +44,17 @@ def test_set_image(cmap, origin, interpolation):
     assert mpl.rcParams["image.interpolation"] == interpolation
 
 
+@pytest.mark.parametrize("despine", [True, False])
+def test_image_despine(despine):
+    isns.set_image(despine=despine)
+
+    _d = not despine
+    assert mpl.rcParams["axes.spines.bottom"] == _d
+    assert mpl.rcParams["axes.spines.top"] == _d
+    assert mpl.rcParams["axes.spines.left"] == _d
+    assert mpl.rcParams["axes.spines.right"] == _d
+
+
 @pytest.mark.parametrize("color", ["white", "k", "C4"])
 @pytest.mark.parametrize("height_fraction", [0.025])
 @pytest.mark.parametrize("length_fraction", [0.3])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -78,6 +78,26 @@ def test_log_scale_cbar():
     plt.close()
 
 
+def test_cbar_despine():
+    # change the global despine state
+    isns.set_image(despine=False)
+    # cbar needs to be True for this test
+    img_setup = isns._core._SetupImage(data, cbar=True)
+    f, ax, cax = img_setup.plot()
+    # changing the global state should reflect here
+    assert img_setup.despine == False
+    plt.close()
+
+    # change the global despine state
+    isns.set_image(despine=True)
+    # cbar needs to be True for this test
+    img_setup = isns._core._SetupImage(data, cbar=True)
+    _ = img_setup.plot()
+    # changing the global state should reflect here
+    assert img_setup.despine == True
+    plt.close()
+
+
 def test_data_plotted_is_same_as_input():
     img_setup = isns._core._SetupImage(data)
     f, ax, cax = img_setup.plot()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,14 +1,15 @@
 import pytest
 
 import matplotlib
+
+matplotlib.use("AGG")  # use non-interactive backend for tests
+
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
 import seaborn_image as isns
-
-matplotlib.use("AGG")  # use non-interactive backend for tests
 
 
 data = np.random.random(2500).reshape((50, 50))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -98,6 +98,38 @@ def test_cbar_despine():
     plt.close()
 
 
+def test_local_despine_wrt_global_despine():
+    # Global despine=False
+    isns.set_image(despine=False)
+
+    img_setup = isns._core._SetupImage(data)
+    f, ax, cax = img_setup.plot()
+    for spine in ["top", "bottom", "right", "left"]:
+        assert ax.spines[spine].get_visible() == True
+
+    # if global state is despine=False but local state is despine=True
+    # it should respect local state
+    img_setup = isns._core._SetupImage(data, despine=True)
+    f, ax, cax = img_setup.plot()
+    for spine in ["top", "bottom", "right", "left"]:
+        assert ax.spines[spine].get_visible() == False
+
+    # Global despine=True
+    isns.set_image(despine=True)
+
+    img_setup = isns._core._SetupImage(data)
+    f, ax, cax = img_setup.plot()
+    for spine in ["top", "bottom", "right", "left"]:
+        assert ax.spines[spine].get_visible() == False
+
+    # if global state is despine=True but local state is despine=False
+    # it should respect local state
+    img_setup = isns._core._SetupImage(data, despine=False)
+    f, ax, cax = img_setup.plot()
+    for spine in ["top", "bottom", "right", "left"]:
+        assert ax.spines[spine].get_visible() == True
+
+
 def test_data_plotted_is_same_as_input():
     img_setup = isns._core._SetupImage(data)
     f, ax, cax = img_setup.plot()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,6 +1,9 @@
 import pytest
 
 import matplotlib
+
+matplotlib.use("AGG")  # use non-interactive backend for tests
+
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.ndimage as ndi
@@ -11,8 +14,6 @@ from skimage.data import astronaut
 from skimage.filters import difference_of_gaussians, window
 
 import seaborn_image as isns
-
-matplotlib.use("AGG")  # use non-interactive backend for tests
 
 
 data = np.random.random(2500).reshape((50, 50))

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1,6 +1,9 @@
 import pytest
 
 import matplotlib
+
+matplotlib.use("AGG")  # use non-interactive backend for tests
+
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.axes import Axes
@@ -9,8 +12,6 @@ from skimage.color import rgb2gray
 from skimage.data import astronaut
 
 import seaborn_image as isns
-
-matplotlib.use("AGG")  # use non-interactive backend for tests
 
 
 data = np.random.random(2500).reshape((50, 50))

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,6 +1,9 @@
 import pytest
 
 import matplotlib
+
+matplotlib.use("AGG")  # use non-interactive backend for tests
+
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.axes import Axes
@@ -8,8 +11,6 @@ from matplotlib.figure import Figure
 from skimage.data import astronaut
 
 import seaborn_image as isns
-
-matplotlib.use("AGG")  # use non-interactive backend for tests
 
 
 class TestImageGrid:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,14 @@
 import pytest
 
 import matplotlib
+
+matplotlib.use("AGG")  # use non-interactive backend for tests
+
 import matplotlib.pyplot as plt
 import numpy as np
 
 import seaborn_image as isns
 
-matplotlib.use("AGG")  # use non-interactive backend for tests
 
 _all = ["top", "bottom", "right", "left"]
 


### PR DESCRIPTION
This PR adds new parameter `despine` to `set_image()` which allows global despining of image axes and colorbar axes. 

`despine` parameters in individual functions still hold (but default is now `None`) and will be given preference over global state if not specified as `None`. 

`isns.despine()` is still available for use as general utility function (Note that `isns.despine()` does not change the global state)