### PR TITLE
`load_image()` can be used outside the repo scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "seaborn-image"
-version = "0.4.0"
+version = "0.4.1-alpha.0"
 description = "seaborn-image: image data visualization and processing like seaborrn using matplotlib, scipy and scikit-image"
 authors = ["Sarthak Jariwala <jariwala@uw.edu>"]
 license = "MIT"

--- a/src/seaborn_image/__init__.py
+++ b/src/seaborn_image/__init__.py
@@ -8,6 +8,7 @@ from ._general import *
 from ._filters import *
 from ._grid import *
 from .utils import *
+from ._datasets import *
 
 
 set_context()

--- a/src/seaborn_image/_datasets.py
+++ b/src/seaborn_image/_datasets.py
@@ -1,0 +1,71 @@
+import numpy as np
+import pooch
+from skimage import io
+
+__all__ = ["load_image"]
+
+
+POOCH = pooch.create(
+    # Use the default cache folder for the OS
+    path=pooch.os_cache("seaborn-image"),
+    # The remote data is on Github
+    base_url="https://raw.githubusercontent.com/SarthakJariwala/seaborn-image/master/data/",
+    # The registry specifies the files that can be fetched
+    registry={
+        # The registry is a dict with file names and their SHA256 hashes
+        "PolymerImage.txt": "7b6798865080adf3ecf11e342f3d86d7b52ea0700020a1f062544ee825fb8a0e",
+        "Perovskite.txt": "3228eeade5afec3c2b1ed116b2d4fe35877224d2d9bf7b4a17e04a432e6135c5",
+    },
+)
+
+
+def load_image(name):
+    """Load image data shippped with seaborn-image.
+
+    Parameters
+    ----------
+    name : str
+        Name of the image dataset
+
+    Raises
+    ------
+    ValueError
+        If the name of the dataset specified doesn't exist
+
+    Returns
+    -------
+    `numpy.ndarray`
+        Image data as a `numpy` array
+
+    Examples
+    --------
+    >>> import seaborn_image as isns
+    >>> img = isns.load_image("polymer")
+    """
+
+    if name == "polymer":
+        path = POOCH.fetch("PolymerImage.txt")
+        img = np.loadtxt(path, skiprows=1)
+        img = img * 1e9  # convert height data from m to nm
+
+    elif name == "polymer outliers":
+        path = POOCH.fetch("PolymerImage.txt")
+        img = np.loadtxt(path, skiprows=1)
+        img = img * 1e9  # convert height data from m to nm
+        img[25, 25] = 80  # assign an outlier value to a random pixel
+
+    elif name == "fluorescence":
+        path = POOCH.fetch("Perovskite.txt")
+        img = np.loadtxt(path)
+
+    elif name == "cells":
+        fname = pooch.retrieve(
+            url="https://github.com/scikit-image/skimage-tutorials/raw/master/images/cells.tif",
+            known_hash="2120cfe08e0396324793a10a905c9bbcb64b117215eb63b2c24b643e1600c8c9",
+        )
+        img = io.imread(fname).T
+
+    else:
+        raise ValueError(f"No '{name}' image dataset")
+
+    return img

--- a/src/seaborn_image/utils.py
+++ b/src/seaborn_image/utils.py
@@ -6,7 +6,7 @@ import pooch
 from matplotlib import ticker
 from skimage import io
 
-__all__ = ["scientific_ticks", "despine", "load_image"]
+__all__ = ["scientific_ticks", "despine"]
 
 
 def scientific_ticks(ax, which="y"):
@@ -166,87 +166,3 @@ def despine(fig=None, ax=None, which="all"):
     for ax in axes:
         for spine in _to_despine:
             ax.spines[spine].set_visible(False)
-
-
-def load_image(name):
-    """Load image data shippped with seaborn-image.
-
-    Parameters
-    ----------
-    name : str
-        Name of the image dataset
-
-    Raises
-    ------
-    ValueError
-        If the name of the dataset specified doesn't exist
-
-    Returns
-    -------
-    `numpy.ndarray`
-        Image data as a `numpy` array
-
-    Examples
-    --------
-    >>> import seaborn_image as isns
-    >>> img = isns.load_image("polymer")
-    """
-
-    if name == "polymer":
-        try:
-            path = "data/PolymerImage.txt"
-            img = np.loadtxt(path, skiprows=1)
-        except OSError:  # pragma: no cover
-            try:
-                # if building docstrings
-                path = "../data/PolymerImage.txt"
-                img = np.loadtxt(path, skiprows=1)
-            except OSError:  # pragma: no cover
-                # if building tuorial
-                path = "../../data/PolymerImage.txt"
-                img = np.loadtxt(path, skiprows=1)
-
-        img = img * 1e9  # convert height data from m to nm
-
-    elif name == "polymer outliers":
-        try:  # not very pretty fix to the path issue
-            path = "data/PolymerImage.txt"
-            img = np.loadtxt(path, skiprows=1)
-        except OSError:  # pragma: no cover
-            try:
-                # if building docstrings
-                path = "../data/PolymerImage.txt"
-                img = np.loadtxt(path, skiprows=1)
-            except OSError:  # pragma : no cover
-                # if building tutorial
-                path = "../../data/PolymerImage.txt"
-                img = np.loadtxt(path, skiprows=1)
-
-        img = img * 1e9  # convert height data from m to nm
-        img[0, 0] = 80  # assign an outlier value to a random pixel
-
-    elif name == "fluorescence":
-        try:  # not very pretty fix to the path issue
-            path = "data/Perovskite.txt"
-            img = np.loadtxt(path)
-        except OSError:  # pragma: no cover
-            try:
-                # if building docstrings
-                path = "../data/Perovskite.txt"
-                img = np.loadtxt(path)
-            except OSError:  # pragma: no cover
-                # if building tutorial
-                path = "../../data/Perovskite.txt"
-                img = np.loadtxt(path)
-
-    elif name == "cells":
-        fname = pooch.retrieve(
-            url="https://github.com/scikit-image/skimage-tutorials/raw/master/images/cells.tif",
-            known_hash="2120cfe08e0396324793a10a905c9bbcb64b117215eb63b2c24b643e1600c8c9",
-        )
-        img = io.imread(fname).T
-
-    else:
-        raise ValueError(f"No '{name}' image dataset")
-
-    return img

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,52 @@
+import pytest
+
+import numpy as np
+import pooch
+from skimage import io
+
+import seaborn_image as isns
+
+
+def test_load_image():
+    # test polymer
+    img = isns.load_image("polymer")
+    fname = pooch.retrieve(
+        url="https://raw.githubusercontent.com/SarthakJariwala/seaborn-image/master/data/PolymerImage.txt",
+        known_hash="7b6798865080adf3ecf11e342f3d86d7b52ea0700020a1f062544ee825fb8a0e",
+    )
+    test_img = np.loadtxt(fname, skiprows=1) * 1e9
+    np.testing.assert_array_equal(img, test_img)
+
+    # test polymer
+    img = isns.load_image("polymer outliers")
+    fname = pooch.retrieve(
+        url="https://raw.githubusercontent.com/SarthakJariwala/seaborn-image/master/data/PolymerImage.txt",
+        known_hash="7b6798865080adf3ecf11e342f3d86d7b52ea0700020a1f062544ee825fb8a0e",
+    )
+    test_img = np.loadtxt(fname, skiprows=1) * 1e9
+    test_img[25, 25] = 80
+    np.testing.assert_array_equal(img, test_img)
+
+    img = isns.load_image("fluorescence")
+    fname = pooch.retrieve(
+        url="https://raw.githubusercontent.com/SarthakJariwala/seaborn-image/master/data/Perovskite.txt",
+        known_hash="3228eeade5afec3c2b1ed116b2d4fe35877224d2d9bf7b4a17e04a432e6135c5",
+    )
+    test_img = np.loadtxt(fname)
+    np.testing.assert_array_equal(img, test_img)
+
+
+def test_load_image_from_skimage():
+    img = isns.load_image("cells")
+
+    fname = pooch.retrieve(
+        url="https://github.com/scikit-image/skimage-tutorials/raw/master/images/cells.tif",
+        known_hash="2120cfe08e0396324793a10a905c9bbcb64b117215eb63b2c24b643e1600c8c9",
+    )
+    test_img = io.imread(fname).T
+    np.testing.assert_array_equal(img, test_img)
+
+
+def test_load_image_error():
+    with pytest.raises(ValueError):
+        isns.load_image("coins")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,38 +53,6 @@ def test_despine_type():
         isns.despine(which=0)
 
 
-def test_load_image():
-    img = isns.load_image("polymer")
-    np.testing.assert_array_equal(
-        img, np.loadtxt("data/PolymerImage.txt", skiprows=1) * 1e9
-    )
-
-    img = isns.load_image("polymer outliers")
-    test_img = np.loadtxt("data/PolymerImage.txt", skiprows=1) * 1e9
-    test_img[0, 0] = 80
-    np.testing.assert_array_equal(img, test_img)
-
-    img = isns.load_image("fluorescence")
-    test_img = np.loadtxt("data/Perovskite.txt")
-    np.testing.assert_array_equal(img, test_img)
-
-
-def test_load_image_from_skimage():
-    img = isns.load_image("cells")
-
-    fname = pooch.retrieve(
-        url="https://github.com/scikit-image/skimage-tutorials/raw/master/images/cells.tif",
-        known_hash="2120cfe08e0396324793a10a905c9bbcb64b117215eb63b2c24b643e1600c8c9",
-    )
-    test_img = io.imread(fname).T
-    np.testing.assert_array_equal(img, test_img)
-
-
-def test_load_image_error():
-    with pytest.raises(ValueError):
-        isns.load_image("coins")
-
-
 def test_scientific_ticks():
     img = isns.load_image("polymer") * 1e-9
 


### PR DESCRIPTION
This PR changes the messy local path based data fetching in `load_image()`. The previous approach prohibited the use of `load_image` outside docs and repo examples. Now, uses [pooch](https://github.com/fatiando/pooch) to fetch and retrieve all data for `load_image()`.

This means calling`isns.load_image()` is no longer confined to docs and examples.