### PR TITLE
Added `imshow` as an alias for `imgplot`

### DIFF
--- a/docs/api/imshow.rst
+++ b/docs/api/imshow.rst
@@ -1,0 +1,4 @@
+seaborn_image.imshow
+====================
+
+.. autofunction:: seaborn_image.imshow

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,7 +47,7 @@ Installation
 
 .. code-block:: bash
 
-    pip install seaborn-image
+    pip install -U seaborn-image
 
 Quick Usage
 ===========

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -6,6 +6,13 @@ Reference
 
 Axes level function to visualize 2-D images.
 
+
+:doc:`imshow <api/imshow>`
+----------------------------
+
+Alias for ``imgplot``. Axes level function to visualize 2-D image data.
+
+
 :doc:`imghist <api/imghist>`
 ----------------------------
 

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -9,8 +9,9 @@ from skimage.color import rgb2gray
 
 from ._colormap import _CMAP_QUAL
 from ._core import _SetupImage
+from .utils import is_documented_by
 
-__all__ = ["imgplot", "imghist"]
+__all__ = ["imgplot", "imghist", "imshow"]
 
 
 def imgplot(
@@ -351,6 +352,14 @@ def imgplot(
         print(f"Mean : {result.mean}")
         print(f"Variance : {result.variance}")
         print(f"Skewness : {result.skewness}")
+
+    return ax
+
+
+@is_documented_by(imgplot)
+def imshow(data, **kwargs):
+
+    ax = imgplot(data, **kwargs)
 
     return ax
 

--- a/src/seaborn_image/utils.py
+++ b/src/seaborn_image/utils.py
@@ -166,3 +166,13 @@ def despine(fig=None, ax=None, which="all"):
     for ax in axes:
         for spine in _to_despine:
             ax.spines[spine].set_visible(False)
+
+
+def is_documented_by(original):
+    "Wrapper to document alias functions"
+
+    def wrapper(target):
+        target.__doc__ = original.__doc__
+        return target
+
+    return wrapper

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -133,6 +133,13 @@ def test_map_func():
         ax.images[0].get_array().data, adjust_gamma(cells, gamma=0.5)
     )
 
+    # imshow with kwargs to test if they are passed on to imgplot
+    ax = isns.imshow(cells, map_func=adjust_gamma, gamma=0.5)
+
+    np.testing.assert_array_equal(
+        ax.images[0].get_array().data, adjust_gamma(cells, gamma=0.5)
+    )
+
 
 def test_cbar_log_and_norm():
     # special case of log-norm


### PR DESCRIPTION
This is mainly for convenience - `isns.imshow` can be used instead of `isns.imgplot` with all the same arguments.

```python
import seaborn_image as inns

pol = isns.load_image("polymer")

ax = isns.imshow(polymer, dx=15, units="nm")
```