### PR TITLE
change base url in POOCH for data retrieval

### DIFF
--- a/src/seaborn_image/_datasets.py
+++ b/src/seaborn_image/_datasets.py
@@ -9,7 +9,7 @@ POOCH = pooch.create(
     # Use the default cache folder for the OS
     path=pooch.os_cache("seaborn-image"),
     # The remote data is on Github
-    base_url="https://raw.githubusercontent.com/SarthakJariwala/seaborn-image/master/data/",
+    base_url="https://github.com/SarthakJariwala/seaborn-image/raw/master/data/",
     # The registry specifies the files that can be fetched
     registry={
         # The registry is a dict with file names and their SHA256 hashes

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -40,7 +40,7 @@ def test_load_image_from_skimage():
     img = isns.load_image("cells")
 
     fname = pooch.retrieve(
-        url="https://github.com/scikit-image/skimage-tutorials/raw/master/images/cells.tif",
+        url="https://github.com/SarthakJariwala/seaborn-image/raw/master/data/cells.tif",
         known_hash="2120cfe08e0396324793a10a905c9bbcb64b117215eb63b2c24b643e1600c8c9",
     )
     test_img = io.imread(fname).T


### PR DESCRIPTION
Changing the base url fixed the `HTTPError` that pooch was running into while downloading data