### PR TITLE
Map multiple functions to images in `ImageGrid`

### DIFF
--- a/examples/plot_ImageGrid_map_func_list.py
+++ b/examples/plot_ImageGrid_map_func_list.py
@@ -13,5 +13,5 @@ g = isns.ImageGrid(
     retina,
     map_func=[meijering, sato, frangi, hessian],
     col_wrap=4,
-    map_func_kwargs=[{"mode": "reflect", "sigmas": [1]} for _ in range(4)],
+    map_func_kw=[{"mode": "reflect", "sigmas": [1]} for _ in range(4)],
 )

--- a/examples/plot_ImageGrid_map_func_list.py
+++ b/examples/plot_ImageGrid_map_func_list.py
@@ -1,0 +1,17 @@
+"""
+Apply multiple transformations to 2-D image
+===========================================
+"""
+
+from skimage.filters import frangi, hessian, meijering, sato
+
+import seaborn_image as isns
+
+retina = isns.load_image("retina-gray")
+
+g = isns.ImageGrid(
+    retina,
+    map_func=[meijering, sato, frangi, hessian],
+    col_wrap=4,
+    map_func_kwargs=[{"mode": "reflect", "sigmas": [1]} for _ in range(4)],
+)

--- a/examples/plot_ImageGrid_map_func_list_to_img_list.py
+++ b/examples/plot_ImageGrid_map_func_list_to_img_list.py
@@ -20,6 +20,4 @@ g = isns.ImageGrid(
     map_func_kwargs=map_func_kwargs,
     col_wrap=2,
     cmap="inferno",
-    dx=[100, 15],
-    units="nm",
 )

--- a/examples/plot_ImageGrid_map_func_list_to_img_list.py
+++ b/examples/plot_ImageGrid_map_func_list_to_img_list.py
@@ -12,12 +12,12 @@ pl = isns.load_image("fluorescence")
 polymer = isns.load_image("polymer")
 
 map_func = [gaussian, median_filter, sobel]
-map_func_kwargs = [{"sigma": 1.5}, {"size": 10}, None]
+map_func_kw = [{"sigma": 1.5}, {"size": 10}, None]
 
 g = isns.ImageGrid(
     [pl, polymer],
     map_func=map_func,
-    map_func_kwargs=map_func_kwargs,
+    map_func_kw=map_func_kw,
     col_wrap=2,
     cmap="inferno",
 )

--- a/examples/plot_ImageGrid_map_func_list_to_img_list.py
+++ b/examples/plot_ImageGrid_map_func_list_to_img_list.py
@@ -1,0 +1,25 @@
+"""
+Apply multiple transformations to list of 2-D images
+====================================================
+"""
+
+from scipy.ndimage import median_filter, sobel
+from skimage.filters import gaussian
+
+import seaborn_image as isns
+
+pl = isns.load_image("fluorescence")
+polymer = isns.load_image("polymer")
+
+map_func = [gaussian, median_filter, sobel]
+map_func_kwargs = [{"sigma": 1.5}, {"size": 10}, None]
+
+g = isns.ImageGrid(
+    [pl, polymer],
+    map_func=map_func,
+    map_func_kwargs=map_func_kwargs,
+    col_wrap=2,
+    cmap="inferno",
+    dx=[100, 15],
+    units="nm",
+)

--- a/examples/plot_ImageGrid_multi.py
+++ b/examples/plot_ImageGrid_multi.py
@@ -7,4 +7,4 @@ import seaborn_image as isns
 
 cells = isns.load_image("cells")
 
-g = isns.ImageGrid(cells, cbar=False, height=1, col_wrap=5, step=2)
+g = isns.ImageGrid(cells, cbar=False, height=1, col_wrap=5, step=2, cmap="inferno")

--- a/examples/plot_ImageGrid_multi_map_func.py
+++ b/examples/plot_ImageGrid_multi_map_func.py
@@ -12,7 +12,7 @@ cells = isns.load_image("cells")
 g = isns.ImageGrid(
     cells,
     map_func=adjust_gamma,
-    gamma=0.5,
+    map_func_kwargs={"gamma": 0.5},
     cbar=False,
     height=1,
     col_wrap=10,

--- a/examples/plot_ImageGrid_multi_map_func.py
+++ b/examples/plot_ImageGrid_multi_map_func.py
@@ -12,7 +12,7 @@ cells = isns.load_image("cells")
 g = isns.ImageGrid(
     cells,
     map_func=adjust_gamma,
-    map_func_kwargs={"gamma": 0.5},
+    map_func_kw={"gamma": 0.5},
     cbar=False,
     height=1,
     col_wrap=10,

--- a/examples/plot_imghist_map_func.py
+++ b/examples/plot_imghist_map_func.py
@@ -10,4 +10,4 @@ import seaborn_image as isns
 
 cells = isns.load_image("cells")[:, :, 32]
 
-f = isns.imghist(cells, map_func=adjust_gamma, gamma=0.5)
+f = isns.imghist(cells, map_func=adjust_gamma, map_func_kw={"gamma": 0.5})

--- a/examples/plot_imghist_map_func.py
+++ b/examples/plot_imghist_map_func.py
@@ -10,4 +10,4 @@ import seaborn_image as isns
 
 cells = isns.load_image("cells")[:, :, 32]
 
-f = isns.imghist(cells, map_func=adjust_gamma, map_func_kw={"gamma": 0.5})
+f = isns.imghist(cells, map_func=adjust_gamma, gamma=0.5)

--- a/src/seaborn_image/_datasets.py
+++ b/src/seaborn_image/_datasets.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pooch
-from skimage import io
+from skimage import color, data, io
 
 __all__ = ["load_image"]
 
@@ -62,6 +62,9 @@ def load_image(name):
     elif name == "cells":
         path = POOCH.fetch("cells.tif")
         img = io.imread(path).T
+
+    elif name == "retina-gray":
+        img = color.rgb2gray(data.retina())[300:700, 700:900]
 
     else:
         raise ValueError(

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -241,6 +241,18 @@ class ImageGrid:
         ...             col_wrap=4,
         ...             map_func_kwargs=[{"mode" : "reflect", "sigmas" : [1]}, None, None, None])
 
+    Apply a list of filters to a list of input images.
+
+    .. plot::
+        :context: close-figs
+
+        >>> from skimage.filters import gaussian, median
+        >>> g = isns.ImageGrid(
+        ...             [pol, pl, retina],
+        ...             map_func=[gaussian, median, hessian],
+        ...             dx=[15, 100, None],
+        ...             units="nm")
+
     Change colorbar orientation
 
     .. plot::

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -34,8 +34,10 @@ class ImageGrid:
         Starting index to select from the the data, by default None
     stop : int, optional
         Stopping index to select from the data, by default None
-    map_func : callable, optional
-        Transform input image data using this function. All function arguments must be passed as kwargs.
+    map_func : callable or list/tuple or callables, optional
+        Transform input image data using this function. All function arguments must be passed as map_func_kwargs.
+    map_func_kwargs : dict or list/tuple of dict, optional
+        kwargs to pass on to `map_func`. Must be dict for a single `map_func` and a list/tuple of dicts for a list/tuple of `map_func`
     col_wrap : int, optional
         Number of columns to display. Defaults to None.
     height : int or float, optional
@@ -215,7 +217,7 @@ class ImageGrid:
         ...             height=1,
         ...             col_wrap=10)
 
-    Map a list of functions to the input data
+    Map a list of functions to the input data. Pass function kwargs to `map_func_kwargs`.
 
     .. plot::
         :context: close-figs
@@ -227,6 +229,17 @@ class ImageGrid:
         ...             map_func=[meijering, sato, frangi, hessian],
         ...             col_wrap=4,
         ...             map_func_kwargs=[{"mode" : "reflect", "sigmas" : [1]} for _ in range(4)])
+
+    If no kwargs are required for one or more of the functions, use `None`.
+
+    .. plot::
+        :context: close-figs
+
+        >>> g = isns.ImageGrid(
+        ...             retina,
+        ...             map_func=[meijering, sato, frangi, hessian],
+        ...             col_wrap=4,
+        ...             map_func_kwargs=[{"mode" : "reflect", "sigmas" : [1]}, None, None, None])
 
     Change colorbar orientation
 
@@ -274,7 +287,6 @@ class ImageGrid:
         cbar_ticks=None,
         showticks=False,
         despine=None,
-        **kwargs,
     ):
         if data is None:
             raise ValueError("image data can not be None")

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -302,6 +302,12 @@ class ImageGrid:
             map_func_type = self._check_map_func(map_func, map_func_kwargs)
             if map_func_type == "list/tuple":
                 _nimages = len(data) * len(map_func)
+                # no of columns should either be len of data list or len of map_func list
+                # whichever is higher
+                if col_wrap is None:
+                    col_wrap = (
+                        len(map_func) if len(map_func) >= len(data) else len(data)
+                    )
 
         elif data.ndim > 3:
             raise ValueError("image data can not have more than 3 dimensions")
@@ -343,6 +349,8 @@ class ImageGrid:
             map_func_type = self._check_map_func(map_func, map_func_kwargs)
             if map_func_type == "list/tuple":
                 _nimages = len(map_func)
+                # no of columns should now be len of map_func list
+                col_wrap = len(map_func) if col_wrap is None else col_wrap
 
         # if no column wrap specified
         # set it to default 3

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -413,8 +413,6 @@ class ImageGrid:
         self._cleanup_extra_axes()
         self._finalize_grid()
 
-        return
-
     def _check_map_func(self, map_func, map_func_kwargs):
         "Check if `map_func` passed is a list/tuple of callables or individual callable"
         if map_func is not None:
@@ -555,11 +553,42 @@ class ImageGrid:
                 f"If supplying a list/tuple, length of {param_list} must be {self._nimages}."
             )
 
+    def _adjust_param_list_len(self, map_func):
+        """
+        If the input data and map_func are both list-like,
+        modify the parameter list such as dx, units, etc such that
+        the length of new parameter list is the same as the number of images.
+
+        # For example -
+        # if data -> [img1, img2], map_func -> [func1, func2, func3]
+        # and dx = [dx1, dx2] # same as len(data)
+        # then for plotting, dx needs to be expanded such that the len(dx) == len(data) * len(map_func)
+        # so, new dx -> [dx1, dx2] * len(map_func)
+        """
+        if isinstance(self.dx, (list, tuple)):
+            self.dx = self.dx * len(map_func)
+
+        if isinstance(self.units, (list, tuple)):
+            self.units = self.units * len(map_func)
+
+        if isinstance(self.dimension, (list, tuple)):
+            self.dimension = self.dimension * len(map_func)
+
+        if isinstance(self.cbar, (list, tuple)):
+            self.cbar = self.cbar * len(map_func)
+
+        if isinstance(self.cbar_label, (list, tuple)):
+            self.cbar_label = self.cbar_label * len(map_func)
+
+        if isinstance(self.cbar_log, (list, tuple)):
+            self.cbar_log = self.cbar_log * len(map_func)
+
     def _map_func_to_data(self, map_func, map_func_kwargs):
         """Transform image data using the map_func callable object."""
         # if data is a list or tuple of 2D images
         if isinstance(self.data, (list, tuple)):
             if self._check_map_func(map_func, map_func_kwargs) == "list/tuple":
+                self._adjust_param_list_len(map_func)
                 _d = self.data
                 # only pass on kwargs if not None
                 if map_func_kwargs is not None:

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -35,8 +35,8 @@ class ImageGrid:
     stop : int, optional
         Stopping index to select from the data, by default None
     map_func : callable or list/tuple or callables, optional
-        Transform input image data using this function. All function arguments must be passed as map_func_kwargs.
-    map_func_kwargs : dict or list/tuple of dict, optional
+        Transform input image data using this function. All function arguments must be passed as map_func_kw.
+    map_func_kw : dict or list/tuple of dict, optional
         kwargs to pass on to `map_func`. Must be dict for a single `map_func` and a list/tuple of dicts for a list/tuple of `map_func`
     col_wrap : int, optional
         Number of columns to display. Defaults to None.
@@ -212,12 +212,12 @@ class ImageGrid:
         >>> g = isns.ImageGrid(
         ...             cells,
         ...             map_func=adjust_gamma,
-        ...             map_func_kwargs={"gamma" : 0.5},
+        ...             map_func_kw={"gamma" : 0.5},
         ...             cbar=False,
         ...             height=1,
         ...             col_wrap=10)
 
-    Map a list of functions to the input data. Pass function kwargs to `map_func_kwargs`.
+    Map a list of functions to the input data. Pass function kwargs to `map_func_kw`.
 
     .. plot::
         :context: close-figs
@@ -228,7 +228,7 @@ class ImageGrid:
         ...             retina,
         ...             map_func=[meijering, sato, frangi, hessian],
         ...             col_wrap=4,
-        ...             map_func_kwargs=[{"mode" : "reflect", "sigmas" : [1]} for _ in range(4)])
+        ...             map_func_kw=[{"mode" : "reflect", "sigmas" : [1]} for _ in range(4)])
 
     If no kwargs are required for one or more of the functions, use `None`.
 
@@ -239,7 +239,7 @@ class ImageGrid:
         ...             retina,
         ...             map_func=[meijering, sato, frangi, hessian],
         ...             col_wrap=4,
-        ...             map_func_kwargs=[{"mode" : "reflect", "sigmas" : [1]}, None, None, None])
+        ...             map_func_kw=[{"mode" : "reflect", "sigmas" : [1]}, None, None, None])
 
     Apply a list of filters to a list of input images.
 
@@ -279,7 +279,7 @@ class ImageGrid:
         start=None,
         stop=None,
         map_func=None,
-        map_func_kwargs=None,
+        map_func_kw=None,
         col_wrap=None,
         height=3,
         aspect=1,
@@ -311,7 +311,7 @@ class ImageGrid:
 
             # --- List/Tuple of 2D images with a List/Tuple of map_func ---
             # change the number of images on the grid accordingly
-            map_func_type = self._check_map_func(map_func, map_func_kwargs)
+            map_func_type = self._check_map_func(map_func, map_func_kw)
             if map_func_type == "list/tuple":
                 _nimages = len(data) * len(map_func)
                 # no of columns should either be len of data list or len of map_func list
@@ -343,7 +343,7 @@ class ImageGrid:
             _nimages = len(slices)
 
             # ---- 3D image with an individual map_func ----
-            map_func_type = self._check_map_func(map_func, map_func_kwargs)
+            map_func_type = self._check_map_func(map_func, map_func_kw)
             # raise a ValueError if a list of map_func is provided for 3d image
             # TODO - support multiple map_func if "chaining"?
             if map_func_type == "list/tuple":
@@ -358,7 +358,7 @@ class ImageGrid:
             # ---- 2D image with a list/tuple of map_func or individual map_func ------
             # check if map_func is a list/tuple of callables
             # and assign the new number of images
-            map_func_type = self._check_map_func(map_func, map_func_kwargs)
+            map_func_type = self._check_map_func(map_func, map_func_kw)
             if map_func_type == "list/tuple":
                 _nimages = len(map_func)
                 # no of columns should now be len of map_func list
@@ -419,35 +419,35 @@ class ImageGrid:
 
         # map function to input data
         if map_func is not None:
-            self._map_func_to_data(map_func, map_func_kwargs)
+            self._map_func_to_data(map_func, map_func_kw)
 
         self._map_img_to_grid()
         self._cleanup_extra_axes()
         self._finalize_grid()
 
-    def _check_map_func(self, map_func, map_func_kwargs):
+    def _check_map_func(self, map_func, map_func_kw):
         "Check if `map_func` passed is a list/tuple of callables or individual callable"
         if map_func is not None:
             if isinstance(map_func, (list, tuple)):
                 for func in map_func:
                     if not callable(func):
                         raise TypeError(f"{func} must be a callable function object")
-                if map_func_kwargs is not None:
-                    if not isinstance(map_func_kwargs, (list, tuple)):
+                if map_func_kw is not None:
+                    if not isinstance(map_func_kw, (list, tuple)):
                         raise TypeError(
-                            "`map_func_kwargs` must be list/tuple of dictionaries"
+                            "`map_func_kw` must be list/tuple of dictionaries"
                         )
-                    if len(map_func_kwargs) != len(map_func):
+                    if len(map_func_kw) != len(map_func):
                         raise ValueError(
-                            "number of `map_func_kwargs` passed must be the same as the number of `map_func` objects"
+                            "number of `map_func_kw` passed must be the same as the number of `map_func` objects"
                         )
                 return "list/tuple"
 
             elif callable(map_func):
-                if map_func_kwargs is not None:
-                    if not isinstance(map_func_kwargs, dict):
+                if map_func_kw is not None:
+                    if not isinstance(map_func_kw, dict):
                         raise TypeError(
-                            "`map_func_kwargs` must be a dictionary when a single `map_func` is passed as input"
+                            "`map_func_kw` must be a dictionary when a single `map_func` is passed as input"
                         )
                 return "callable"
 
@@ -595,23 +595,21 @@ class ImageGrid:
         if isinstance(self.cbar_log, (list, tuple)):
             self.cbar_log = self.cbar_log * len(map_func)
 
-    def _map_func_to_data(self, map_func, map_func_kwargs):
+    def _map_func_to_data(self, map_func, map_func_kw):
         """Transform image data using the map_func callable object."""
         # if data is a list or tuple of 2D images
         if isinstance(self.data, (list, tuple)):
-            if self._check_map_func(map_func, map_func_kwargs) == "list/tuple":
+            if self._check_map_func(map_func, map_func_kw) == "list/tuple":
                 self._adjust_param_list_len(map_func)
                 _d = self.data
                 # only pass on kwargs if not None
-                if map_func_kwargs is not None:
+                if map_func_kw is not None:
                     # check if one of the supplied kwargs in the list is None
                     # if None - change it to empty {}
-                    map_func_kwargs = [
-                        {} if kw is None else kw for kw in map_func_kwargs
-                    ]
+                    map_func_kw = [{} if kw is None else kw for kw in map_func_kw]
                     self.data = [
                         func(img, **kwargs)
-                        for func, kwargs in zip(map_func, map_func_kwargs)
+                        for func, kwargs in zip(map_func, map_func_kw)
                         for img in _d
                     ]
                 else:
@@ -619,32 +617,30 @@ class ImageGrid:
             else:  # if map_func is callable
                 for i in range(len(self.data)):
                     # only pass on kwargs if not None
-                    if map_func_kwargs is not None:
-                        self.data[i] = map_func(self.data[i], **map_func_kwargs)
+                    if map_func_kw is not None:
+                        self.data[i] = map_func(self.data[i], **map_func_kw)
                     else:
                         self.data[i] = map_func(self.data[i])
 
         # if data is 3D or 2D and map_func is single callable
         else:
-            if self._check_map_func(map_func, map_func_kwargs) == "callable":
+            if self._check_map_func(map_func, map_func_kw) == "callable":
                 # only pass on kwargs if not None
-                if map_func_kwargs is not None:
-                    self.data = map_func(self.data, **map_func_kwargs)
+                if map_func_kw is not None:
+                    self.data = map_func(self.data, **map_func_kw)
                 else:
                     self.data = map_func(self.data)
             # list of callables -- only for 2D image
             else:
                 _d = self.data
                 # only pass on kwargs if not None
-                if map_func_kwargs is not None:
+                if map_func_kw is not None:
                     # check if one of the supplied kwargs in the list is None
                     # if None - change it to empty {}
-                    map_func_kwargs = [
-                        {} if kw is None else kw for kw in map_func_kwargs
-                    ]
+                    map_func_kw = [{} if kw is None else kw for kw in map_func_kw]
                     self.data = [
                         func(_d, **kwargs)
-                        for func, kwargs in zip(map_func, map_func_kwargs)
+                        for func, kwargs in zip(map_func, map_func_kw)
                     ]
                 else:
                     self.data = [func(_d) for func in map_func]

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -119,7 +119,9 @@ class ImageGrid:
     ValueError
         If `axis` is not 0, 1, 2 or -1
     TypeError
-        If `map_func` is not a callable object
+        If `map_func` is not a callable object or a list/tuple of callable objects
+    ValueError
+        If `map_func` is a list/tuple of callable objects when `data` is 3D
 
     Examples
     --------
@@ -212,6 +214,20 @@ class ImageGrid:
         ...             cbar=False,
         ...             height=1,
         ...             col_wrap=10)
+
+    Map a list of functions to the input data
+
+    .. plot::
+        :context: close-figs
+
+        >>> from skimage.filters import meijering, sato, frangi, hessian
+        >>> retina = isns.load_image("retina-gray")
+        >>> g = isns.ImageGrid(
+        ...             retina,
+        ...             map_func=[meijering, sato, frangi, hessian],
+        ...             col_wrap=4,
+        ...             mode="reflect",
+        ...             sigmas=[1])
 
     Change colorbar orientation
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -2,7 +2,7 @@ import pytest
 
 import numpy as np
 import pooch
-from skimage import io
+from skimage import color, data, io
 
 import seaborn_image as isns
 
@@ -44,6 +44,10 @@ def test_load_image_from_skimage():
         known_hash="2120cfe08e0396324793a10a905c9bbcb64b117215eb63b2c24b643e1600c8c9",
     )
     test_img = io.imread(fname).T
+    np.testing.assert_array_equal(img, test_img)
+
+    img = isns.load_image("retina-gray")
+    test_img = color.rgb2gray(data.retina())[300:700, 700:900]
     np.testing.assert_array_equal(img, test_img)
 
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -83,9 +83,11 @@ class TestImageGrid:
 
     def test_map_func(self):
 
+        # test map_func is callable
         with pytest.raises(TypeError):
             isns.ImageGrid(self.img_3d, map_func="gaussian")
 
+        # 3D image with single map_func
         g0 = isns.ImageGrid(self.img_3d, map_func=gaussian)
         ax = g0.axes.flat
         np.testing.assert_array_equal(
@@ -96,6 +98,7 @@ class TestImageGrid:
         )
         plt.close()
 
+        # List of 2D images with single map_func
         pol = isns.load_image("polymer")
         pl = isns.load_image("fluorescence")
         new_img_list = [pol, pl]
@@ -105,7 +108,29 @@ class TestImageGrid:
         np.testing.assert_array_equal(ax[1].images[0].get_array().data, gaussian(pl))
         plt.close()
 
-        # test kwargs
+        # Single 2D image with a single map_func
+        g = isns.ImageGrid(pol, map_func=gaussian)
+        ax = g.axes.flat
+        np.testing.assert_array_equal(ax[0].images[0].get_array().data, gaussian(pol))
+        plt.close()
+
+        # Single 2D image with a list of map_func
+        g = isns.ImageGrid(pol, map_func=[gaussian, gaussian])
+        ax = g.axes.flat
+        np.testing.assert_array_equal(ax[0].images[0].get_array().data, gaussian(pol))
+        np.testing.assert_array_equal(ax[1].images[0].get_array().data, gaussian(pol))
+        plt.close()
+
+        # List of 2D images with a list of map_func
+        g = isns.ImageGrid([pol, pl], map_func=[gaussian, gaussian])
+        ax = g.axes.flat
+        np.testing.assert_array_equal(ax[0].images[0].get_array().data, gaussian(pol))
+        np.testing.assert_array_equal(ax[1].images[0].get_array().data, gaussian(pl))
+        np.testing.assert_array_equal(ax[2].images[0].get_array().data, gaussian(pol))
+        np.testing.assert_array_equal(ax[3].images[0].get_array().data, gaussian(pl))
+        plt.close()
+
+        # test kwargs for a single map_func
         g2 = isns.ImageGrid(self.img_3d, map_func=gaussian, sigma=1.5)
         ax = g2.axes.flat
         np.testing.assert_array_equal(

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -7,7 +7,7 @@ from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 from scipy import ndimage as ndi
 from skimage.data import astronaut
-from skimage.filters import gaussian, hessian
+from skimage.filters import gaussian, hessian, median
 
 import seaborn_image as isns
 
@@ -230,6 +230,40 @@ class TestImageGrid:
             g = isns.ImageGrid(
                 [pol, pl], map_func=gaussian, map_func_kwargs=[{"sigma": 1.5}]
             )
+
+    def test_param_list_with_map_func(self):
+        """
+        If the input data and map_func are both list-like,
+        modify the parameter list such as dx, units, etc such that
+        the length of new parameter list is the same as the number of images.
+
+        # For example -
+        # if data -> [img1, img2], map_func -> [func1, func2, func3]
+        # and dx = [dx1, dx2] # same as len(data)
+        # then for plotting, dx needs to be expanded such that the len(dx) == len(data) * len(map_func)
+        # so, new dx -> [dx1, dx2] * len(map_func)
+        # and len(dx) == len(nimages)
+        """
+        # when param is passed as list/tuple and data as well as map_func is a list
+        pol = isns.load_image("polymer")
+        pl = isns.load_image("fluorescence")
+        g = isns.ImageGrid(
+            [pol, pl],
+            dx=[15, 100],
+            units=["nm", "nm"],
+            dimension=["si", "si"],
+            cbar=[True, True],
+            cbar_label=["Height (nm)", "Intensity (au)"],
+            cbar_log=[False, True],
+            map_func=[gaussian, median, hessian],
+        )
+
+        assert len(g.dx) == g._nimages
+        assert len(g.units) == g._nimages
+        assert len(g.dimension) == g._nimages
+        assert len(g.cbar) == g._nimages
+        assert len(g.cbar_label) == g._nimages
+        assert len(g.cbar_log) == g._nimages
 
     def test_col_wrap(self):
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -139,12 +139,10 @@ class TestImageGrid:
         with pytest.raises(TypeError):
             g = isns.ImageGrid([pol, pl], map_func=[gaussian, "hessian"])
 
-    def test_map_func_kwargs(self):
+    def test_map_func_kw(self):
 
         # kwargs for a single map_func for 3D image
-        g = isns.ImageGrid(
-            self.img_3d, map_func=gaussian, map_func_kwargs={"sigma": 1.5}
-        )
+        g = isns.ImageGrid(self.img_3d, map_func=gaussian, map_func_kw={"sigma": 1.5})
         ax = g.axes.flat
         np.testing.assert_array_equal(
             ax[0].images[0].get_array().data, gaussian(self.img_3d, sigma=1.5)[:, :, 0]
@@ -157,7 +155,7 @@ class TestImageGrid:
         # kwargs for single map_func for list of 2D images
         pol = isns.load_image("polymer")
         pl = isns.load_image("fluorescence")
-        g = isns.ImageGrid([pol, pl], map_func=gaussian, map_func_kwargs={"sigma": 1.5})
+        g = isns.ImageGrid([pol, pl], map_func=gaussian, map_func_kw={"sigma": 1.5})
         ax = g.axes.flat
         np.testing.assert_array_equal(
             ax[0].images[0].get_array().data, gaussian(pol, sigma=1.5)
@@ -168,7 +166,7 @@ class TestImageGrid:
         plt.close()
 
         # kwargs for single map_func for a single 2D image
-        g = isns.ImageGrid(pol, map_func=gaussian, map_func_kwargs={"sigma": 1.5})
+        g = isns.ImageGrid(pol, map_func=gaussian, map_func_kw={"sigma": 1.5})
         ax = g.axes.flat
         np.testing.assert_array_equal(
             ax[0].images[0].get_array().data, gaussian(pol, sigma=1.5)
@@ -176,10 +174,10 @@ class TestImageGrid:
         plt.close()
 
         # kwargs for a list of map_func for a single 2D image
-        # Also, test for any None elements in map_func_kwargs list
+        # Also, test for any None elements in map_func_kw list
         map_func = [gaussian, ndi.median_filter, gaussian]
-        map_func_kwargs = [{"sigma": 1.5}, {"size": 10}, None]
-        g = isns.ImageGrid(pol, map_func=map_func, map_func_kwargs=map_func_kwargs)
+        map_func_kw = [{"sigma": 1.5}, {"size": 10}, None]
+        g = isns.ImageGrid(pol, map_func=map_func, map_func_kw=map_func_kw)
         ax = g.axes.flat
         np.testing.assert_array_equal(
             ax[0].images[0].get_array().data, gaussian(pol, sigma=1.5)
@@ -190,10 +188,8 @@ class TestImageGrid:
         np.testing.assert_array_equal(ax[2].images[0].get_array().data, gaussian(pol))
         plt.close()
 
-        # List of 2D images with a list of map_func and list of map_func_kwargs
-        g = isns.ImageGrid(
-            [pol, pl], map_func=map_func, map_func_kwargs=map_func_kwargs
-        )
+        # List of 2D images with a list of map_func and list of map_func_kw
+        g = isns.ImageGrid([pol, pl], map_func=map_func, map_func_kw=map_func_kw)
         ax = g.axes.flat
         np.testing.assert_array_equal(
             ax[0].images[0].get_array().data, gaussian(pol, sigma=1.5)
@@ -211,24 +207,22 @@ class TestImageGrid:
         np.testing.assert_array_equal(ax[5].images[0].get_array().data, gaussian(pl))
         plt.close()
 
-        # `map_func_kwargs` must be list/tuple of dictionaries if map_func is a list/tuple
+        # `map_func_kw` must be list/tuple of dictionaries if map_func is a list/tuple
         with pytest.raises(TypeError):
-            g = isns.ImageGrid(
-                [pol, pl], map_func=map_func, map_func_kwargs={"sigma": 1.5}
-            )
+            g = isns.ImageGrid([pol, pl], map_func=map_func, map_func_kw={"sigma": 1.5})
 
-        # number of `map_func_kwargs` passed must be the same as the number of `map_func` objects"
+        # number of `map_func_kw` passed must be the same as the number of `map_func` objects"
         with pytest.raises(ValueError):
             g = isns.ImageGrid(
                 [pol, pl],
                 map_func=map_func,
-                map_func_kwargs=[{"sigma": 1.5}, {"sigma": 1.5}],
+                map_func_kw=[{"sigma": 1.5}, {"sigma": 1.5}],
             )
 
-        # map_func_kwargs` must be a dictionary when a single `map_func` is passed as input
+        # map_func_kw` must be a dictionary when a single `map_func` is passed as input
         with pytest.raises(TypeError):
             g = isns.ImageGrid(
-                [pol, pl], map_func=gaussian, map_func_kwargs=[{"sigma": 1.5}]
+                [pol, pl], map_func=gaussian, map_func_kw=[{"sigma": 1.5}]
             )
 
     def test_param_list_with_map_func(self):
@@ -285,20 +279,18 @@ class TestImageGrid:
         pol = isns.load_image("polymer")
         pl = isns.load_image("fluorescence")
         map_func = [gaussian, ndi.median_filter, hessian]
-        map_func_kwargs = [{"sigma": 1.5}, {"size": 10}, None]
+        map_func_kw = [{"sigma": 1.5}, {"size": 10}, None]
 
-        g = isns.ImageGrid(pl, map_func=map_func, map_func_kwargs=map_func_kwargs)
+        g = isns.ImageGrid(pl, map_func=map_func, map_func_kw=map_func_kw)
         assert g.axes.shape == (1, 3)
         plt.close()
 
-        g = isns.ImageGrid(
-            [pl, pol], map_func=map_func, map_func_kwargs=map_func_kwargs
-        )
+        g = isns.ImageGrid([pl, pol], map_func=map_func, map_func_kw=map_func_kw)
         assert g.axes.shape == (2, 3)
         plt.close()
 
         g = isns.ImageGrid(
-            [pl, pol], map_func=map_func, map_func_kwargs=map_func_kwargs, col_wrap=2
+            [pl, pol], map_func=map_func, map_func_kw=map_func_kw, col_wrap=2
         )
         assert g.axes.shape == (3, 2)
         plt.close()

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -130,6 +130,14 @@ class TestImageGrid:
         np.testing.assert_array_equal(ax[3].images[0].get_array().data, gaussian(pl))
         plt.close()
 
+        # 3 Image with list of map_func
+        with pytest.raises(ValueError):
+            g = isns.ImageGrid(self.img_3d, map_func=[gaussian, gaussian])
+
+        # List of map_func must all be callables
+        with pytest.raises(TypeError):
+            g = isns.ImageGrid([pol, pl], map_func=[gaussian, "hessian"])
+
         # test kwargs for a single map_func
         g2 = isns.ImageGrid(self.img_3d, map_func=gaussian, sigma=1.5)
         ax = g2.axes.flat

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -7,7 +7,7 @@ from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 from scipy import ndimage as ndi
 from skimage.data import astronaut
-from skimage.filters import gaussian
+from skimage.filters import gaussian, hessian
 
 import seaborn_image as isns
 
@@ -245,6 +245,32 @@ class TestImageGrid:
 
         g2 = isns.ImageGrid(self.img_3d, col_wrap=3)
         assert g2.axes.shape == (2, 3)
+        plt.close()
+
+        # test col_wrap with map_func
+        pol = isns.load_image("polymer")
+        pl = isns.load_image("fluorescence")
+        map_func = [gaussian, ndi.median_filter, hessian]
+        map_func_kwargs = [{"sigma": 1.5}, {"size": 10}, None]
+
+        g = isns.ImageGrid(pl, map_func=map_func, map_func_kwargs=map_func_kwargs)
+        assert g.axes.shape == (1, 3)
+        plt.close()
+
+        g = isns.ImageGrid(
+            [pl, pol], map_func=map_func, map_func_kwargs=map_func_kwargs
+        )
+        assert g.axes.shape == (2, 3)
+        plt.close()
+
+        g = isns.ImageGrid(
+            [pl, pol], map_func=map_func, map_func_kwargs=map_func_kwargs, col_wrap=2
+        )
+        assert g.axes.shape == (3, 2)
+        plt.close()
+
+        g = isns.ImageGrid([pl, pol], map_func=gaussian)
+        assert g.axes.shape == (1, 2)
         plt.close()
 
     def test_slices(self):

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -460,6 +460,20 @@ class TestFilterGrid(object):
         assert isinstance(g.fig, Figure)
         plt.close()
 
+    def test_rows(self):
+        with pytest.raises(TypeError):
+            _ = isns.FilterGrid(self.data, "gaussian", row=gaussian, sigma=[1, 2, 3])
+
+        with pytest.raises(ValueError):
+            _ = isns.FilterGrid(self.data, "gaussian", row="sigma")
+
+    def test_cols(self):
+        with pytest.raises(TypeError):
+            _ = isns.FilterGrid(self.data, "gaussian", col=gaussian, sigma=[1, 2, 3])
+
+        with pytest.raises(ValueError):
+            _ = isns.FilterGrid(self.data, "gaussian", col="sigma")
+
     def test_self_axes(self):
 
         g0 = isns.FilterGrid(self.data, "sobel")


### PR DESCRIPTION
`ImageGrid` gains the ability to map multiple functions to the input image/s. Overall, there are 4 use cases : 

- `List` of `map_func` mapped to a `List` of 2D images
```python
g = isns.ImageGrid([img1, img2, img3], map_func=[f1, f2, f3])
```
- `List` of `map_func` applied to a single 2D image
```python
g = isns.ImageGrid(img_2d, map_func=[f1, f2, f3])
```
- Single `map_func` applied to a list of 2D images
```python
g = isns.ImageGrid([img1, img2, img3], map_func=f3)
```
- Single `map_func` applied to a 3D image
```python
g = isns.ImageGrid(img_3d, map_func=f1)
```


Parameters for individual functions can also be passed as a `Dict` or `List` of `Dict`s to `map_func_kw` parameter in `ImageGrid`

For eg - 
```python
from skimage.filters import gaussian, hessian, median

g = isns.ImageGrid(
    [img1, img2],
    map_func=[gaussian, median, hessian],
    map_func_kw=[{"sigma" : 2}, None, {"mode" : "reflect"}]
)
```

This PR also adds a new dataset `retina-gray` for documentation purposes.
```python
retina = isns.load_image("retina-gray")
```