### PR TITLE
fix `imghist` docstring

### DIFF
--- a/src/seaborn_image/_context.py
+++ b/src/seaborn_image/_context.py
@@ -128,7 +128,7 @@ def set_image(cmap="deep", origin="lower", interpolation="nearest", despine=Fals
         try:
             register_cmap(name=cmap, cmap=cmap_mpl)
         # above line will raise ValueError in matplotlib>3.6 if cmap already registered
-        except ValueError: # noqa
+        except ValueError:  # pragma: no cover
             pass
 
     # change the axes spines

--- a/src/seaborn_image/_context.py
+++ b/src/seaborn_image/_context.py
@@ -125,7 +125,11 @@ def set_image(cmap="deep", origin="lower", interpolation="nearest", despine=Fals
 
     if cmap in _CMAP_QUAL.keys():  # doesn't work currently
         cmap_mpl = _CMAP_QUAL.get(cmap).mpl_colormap
-        register_cmap(name=cmap, cmap=cmap_mpl)
+        try:
+            register_cmap(name=cmap, cmap=cmap_mpl)
+        # above line will raise ValueError in matplotlib>3.6 if cmap already registered
+        except ValueError: # noqa
+            pass
 
     # change the axes spines
     # "not" is required because of the despine parameter name

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -402,8 +402,6 @@ def imghist(
         Image data. Supported array shapes are all `matplotlib.pyplot.imshow` array shapes
     bins : int, optional
         Histogram bins, by default None. If None, `auto` is used.
-    ax : `matplotlib.axes.Axes`, optional
-        Matplotlib axes to plot image on. If None, figure and axes are auto-generated, by default None
     cmap : str or `matplotlib.colors.Colormap`, optional
         Colormap for image. Can be a seaborn-image colormap or default matplotlib colormaps or
         any other colormap converted to a matplotlib colormap, by default None


### PR DESCRIPTION
remove `ax` param from docstring: wasn't available in function parameters

closes #479