### PR TITLE
Changed default RGB color maps and added normalization to ImageGrid

### DIFF
--- a/src/seaborn_image/_colormap.py
+++ b/src/seaborn_image/_colormap.py
@@ -1,7 +1,6 @@
 import inspect
 
 import matplotlib as mpl
-# import matplotlib.pyplot as plt
 
 from palettable.cartocolors.sequential import *
 from palettable.cmocean.sequential import *
@@ -62,7 +61,7 @@ _CMAP_QUAL = {
 }
 
  
-# For plotting image channels 
+# Extra color maps for various purposes like showing RGB channels of an image
 _CMAP_EXTRA = {
     "R": mpl.colors.LinearSegmentedColormap.from_list("R", ["#000000", "#FF0000"]),
     "G": mpl.colors.LinearSegmentedColormap.from_list("G", ["#000000", "#00FF00"]),
@@ -71,12 +70,3 @@ _CMAP_EXTRA = {
     "M": mpl.colors.LinearSegmentedColormap.from_list("M", ["#FFFFFF", "#FF00FF"]),
     "Y": mpl.colors.LinearSegmentedColormap.from_list("Y", ["#FFFFFF", "#FFFF00"]),
 }
-
-# For image channels
-# mpl.colormaps.register(mpl.colors.LinearSegmentedColormap.from_list("R", ["#000000", "#FF0000"]))
-# mpl.colormaps.register(mpl.colors.LinearSegmentedColormap.from_list("G", ["#000000", "#00FF00"]))
-# mpl.colormaps.register(mpl.colors.LinearSegmentedColormap.from_list("B", ["#000000", "#0000FF"]))
-
-# mpl.colormaps.register(mpl.colors.LinearSegmentedColormap.from_list("C", ["#FFFFFF", "#00FFFF"]))
-# mpl.colormaps.register(mpl.colors.LinearSegmentedColormap.from_list("M", ["#FFFFFF", "#FF00FF"]))
-# mpl.colormaps.register(mpl.colors.LinearSegmentedColormap.from_list("Y", ["#FFFFFF", "#FFFF00"]))

--- a/src/seaborn_image/_colormap.py
+++ b/src/seaborn_image/_colormap.py
@@ -1,5 +1,8 @@
 import inspect
 
+import matplotlib as mpl
+# import matplotlib.pyplot as plt
+
 from palettable.cartocolors.sequential import *
 from palettable.cmocean.sequential import *
 from palettable.colorbrewer.sequential import *
@@ -57,3 +60,23 @@ _CMAP_QUAL = {
     "sunset-dark": SunsetDark_7_r,
     "sunset": Sunset_7_r,
 }
+
+ 
+# For plotting image channels 
+_CMAP_EXTRA = {
+    "R": mpl.colors.LinearSegmentedColormap.from_list("R", ["#000000", "#FF0000"]),
+    "G": mpl.colors.LinearSegmentedColormap.from_list("G", ["#000000", "#00FF00"]),
+    "B": mpl.colors.LinearSegmentedColormap.from_list("B", ["#000000", "#0000FF"]),
+    "C": mpl.colors.LinearSegmentedColormap.from_list("C", ["#FFFFFF", "#00FFFF"]),
+    "M": mpl.colors.LinearSegmentedColormap.from_list("M", ["#FFFFFF", "#FF00FF"]),
+    "Y": mpl.colors.LinearSegmentedColormap.from_list("Y", ["#FFFFFF", "#FFFF00"]),
+}
+
+# For image channels
+# mpl.colormaps.register(mpl.colors.LinearSegmentedColormap.from_list("R", ["#000000", "#FF0000"]))
+# mpl.colormaps.register(mpl.colors.LinearSegmentedColormap.from_list("G", ["#000000", "#00FF00"]))
+# mpl.colormaps.register(mpl.colors.LinearSegmentedColormap.from_list("B", ["#000000", "#0000FF"]))
+
+# mpl.colormaps.register(mpl.colors.LinearSegmentedColormap.from_list("C", ["#FFFFFF", "#00FFFF"]))
+# mpl.colormaps.register(mpl.colors.LinearSegmentedColormap.from_list("M", ["#FFFFFF", "#FF00FF"]))
+# mpl.colormaps.register(mpl.colors.LinearSegmentedColormap.from_list("Y", ["#FFFFFF", "#FFFF00"]))

--- a/src/seaborn_image/_context.py
+++ b/src/seaborn_image/_context.py
@@ -2,9 +2,8 @@ import warnings
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
-from matplotlib.cm import register_cmap
 
-from ._colormap import _CMAP_QUAL
+from ._colormap import _CMAP_QUAL, _CMAP_EXTRA
 
 __all__ = [
     "set_context",
@@ -123,13 +122,18 @@ def set_image(cmap="deep", origin="lower", interpolation="nearest", despine=Fals
 
     """
 
+    # Load colormap from palletable 
     if isinstance(cmap, str) and cmap in _CMAP_QUAL.keys():
-        cmap_mpl = _CMAP_QUAL.get(cmap).mpl_colormap
-        try:
-            register_cmap(name=cmap, cmap=cmap_mpl)
-        # above line will raise ValueError in matplotlib>3.6 if cmap already registered
-        except ValueError:  # pragma: no cover
-            pass
+        cmap_qual_mpl = _CMAP_QUAL.get(cmap).mpl_colormap
+        if cmap not in mpl.colormaps.keys():
+            mpl.colormaps.register(name=cmap, cmap=cmap_qual_mpl)
+    
+    # Load extra colormap
+    if isinstance(cmap, str) and cmap in _CMAP_EXTRA.keys():
+        cmap_channel_mpl = _CMAP_EXTRA.get(cmap)
+        if cmap not in mpl.colormaps.keys():
+            mpl.colormaps.register(name=cmap, cmap=cmap_channel_mpl)
+        
 
     # change the axes spines
     # "not" is required because of the despine parameter name

--- a/src/seaborn_image/_core.py
+++ b/src/seaborn_image/_core.py
@@ -5,7 +5,7 @@ import numpy as np
 from matplotlib_scalebar.scalebar import ScaleBar
 from mpl_toolkits.axes_grid1 import axes_size, make_axes_locatable
 
-from ._colormap import _CMAP_QUAL
+from ._colormap import _CMAP_QUAL, _CMAP_EXTRA
 from .utils import despine, scientific_ticks
 
 # dimensions for scalebar
@@ -104,6 +104,9 @@ class _SetupImage(object):
 
         if isinstance(self.cmap, str) and self.cmap in _CMAP_QUAL.keys():
             self.cmap = _CMAP_QUAL.get(self.cmap).mpl_colormap
+        
+        if isinstance(self.cmap, str) and self.cmap in _CMAP_EXTRA.keys():
+            self.cmap = _CMAP_EXTRA.get(cmap)
 
         if self.robust:
             min_robust = False

--- a/src/seaborn_image/_core.py
+++ b/src/seaborn_image/_core.py
@@ -106,7 +106,7 @@ class _SetupImage(object):
             self.cmap = _CMAP_QUAL.get(self.cmap).mpl_colormap
         
         if isinstance(self.cmap, str) and self.cmap in _CMAP_EXTRA.keys():
-            self.cmap = _CMAP_EXTRA.get(cmap)
+            self.cmap = _CMAP_EXTRA.get(self.cmap)
 
         if self.robust:
             min_robust = False

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -7,7 +7,7 @@ from matplotlib.cm import get_cmap
 from matplotlib.colors import Colormap
 from skimage.color import rgb2gray
 
-from ._colormap import _CMAP_QUAL
+from ._colormap import _CMAP_QUAL, _CMAP_EXTRA
 from ._core import _SetupImage
 from .utils import is_documented_by
 
@@ -652,6 +652,8 @@ def imghist(
     else:
         if cmap in _CMAP_QUAL.keys():
             cm = _CMAP_QUAL.get(cmap).mpl_colormap
+        elif cmap in _CMAP_EXTRA.keys():
+            cm = _CMAP_EXTRA.get(cmap)
         else:
             cm = plt.cm.get_cmap(cmap)
 

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -67,10 +67,9 @@ class ImageGrid:
         Maximum data value that colormap covers, by default None
     interpolation : str, optional
         `matplotlib.pyplot.imshow` interpolation method used, by default None
-    norm : `matplotlib.colors.Normalize`, optional
+    norm : `matplotlib.colors.Normalize` or list of `matplotlib.colors.Normalize`, optional
         `matplotlib` Normalize instance used to scale scalar data before
         mapping to colors using cmap.
-        For the moment being the same normalization is used for all images in the grid.
     dx : float or list, optional
         Size per pixel of the image data. If scalebar
         is required, `dx` and `units` must be sepcified.

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -4,6 +4,7 @@ from typing import Iterable
 
 import matplotlib.pyplot as plt
 import numpy as np
+import skimage.color
 
 from ._filters import filterplot
 from ._general import imgplot
@@ -67,6 +68,10 @@ class ImageGrid:
         Maximum data value that colormap covers, by default None
     interpolation : str, optional
         `matplotlib.pyplot.imshow` interpolation method used, by default None
+    norm : `matplotlib.colors.Normalize`, optional
+        `matplotlib` Normalize instance used to scale scalar data before
+        mapping to colors using cmap.
+        For the moment being the same normalization is used for all images in the grid.
     dx : float or list, optional
         Size per pixel of the image data. If scalebar
         is required, `dx` and `units` must be sepcified.
@@ -302,6 +307,7 @@ class ImageGrid:
         vmin=None,
         vmax=None,
         interpolation=None,
+        norm=None,
         dx=None,
         units=None,
         dimension=None,
@@ -417,6 +423,7 @@ class ImageGrid:
         self.vmin = vmin
         self.vmax = vmax
         self.interpolation = interpolation
+        self.norm = norm
         self.dx = dx
         self.units = units
         self.dimension = dimension
@@ -566,6 +573,7 @@ class ImageGrid:
                 alpha=self.alpha,
                 origin=self.origin,
                 interpolation=self.interpolation,
+                norm=self.norm,
                 dx=_dx,
                 units=_units,
                 dimension=_dimension,
@@ -834,14 +842,14 @@ def rgbplot(
     """
 
     if not data.ndim == 3:
-        raise ValueError("imput image must be a RGB image")
+        raise ValueError("input image must be a RGB image")
 
     if data.shape[-1] != 3:
         raise ValueError("input image must be a RGB image")
 
     # if no cmap, assign reds, greens and blues cmap
     if cmap is None:
-        cmap = ["Reds", "Greens", "Blues"]
+        cmap = ["R", "G", "B"]
 
     # split RGB channels
     _d = [data[:, :, 0], data[:, :, 1], data[:, :, 2]]

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -4,7 +4,6 @@ from typing import Iterable
 
 import matplotlib.pyplot as plt
 import numpy as np
-import skimage.color
 
 from ._filters import filterplot
 from ._general import imgplot

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -485,6 +485,7 @@ class ImageGrid:
         _perc = self.perc
         _vmin = self.vmin
         _vmax = self.vmax
+        _norm = self.norm
         _dx = self.dx
         _units = self.units
         _dimension = self.dimension
@@ -536,6 +537,10 @@ class ImageGrid:
             if isinstance(self.perc, (list)):
                 self._check_len_wrt_n_images(self.perc)
                 _perc = self.perc[i]
+            
+            if isinstance(self.norm, (list)):
+                self._check_len_wrt_n_images(self.norm)
+                _norm = self.norm[i]
 
             if isinstance(self.dx, (list, tuple)):
                 self._check_len_wrt_n_images(self.dx)
@@ -572,7 +577,7 @@ class ImageGrid:
                 alpha=self.alpha,
                 origin=self.origin,
                 interpolation=self.interpolation,
-                norm=self.norm,
+                norm=_norm,
                 dx=_dx,
                 units=_units,
                 dimension=_dimension,

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -595,11 +595,11 @@ def test_rgbplot_data(img):
 
 def test_rgbplot_cmap():
     g = isns.rgbplot(astronaut())
-    g.cmap = ["Reds", "Greens", "Blues"]
+    assert g.cmap == ["R", "G", "B"]
     plt.close()
 
     g = isns.rgbplot(astronaut(), cmap=["inferno", "viridis", "ice"])
-    g.cmap = ["inferno", "viridis", "ice"]
+    assert g.cmap == ["inferno", "viridis", "ice"]
     plt.close()
 
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -2,6 +2,7 @@ import pytest
 
 import matplotlib
 import matplotlib.pyplot as plt
+import matplotlib.colors as colors
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
@@ -384,6 +385,24 @@ class TestImageGrid:
 
         with pytest.raises(AssertionError):
             isns.ImageGrid(self.img_3d, cmap=["Reds"])
+            plt.close()
+    
+    def test_norm_list(self):
+        
+        norm_list1 = [colors.LogNorm(vmin=1e-4, vmax=1), colors.CenteredNorm(), colors.PowerNorm(gamma=0.5)]
+        isns.ImageGrid(self.img_list, norm=norm_list1)
+        plt.close()
+
+        norm_list2 = [colors.LogNorm(vmin=1e-4, vmax=1), None, None]
+        isns.ImageGrid(self.img_list, norm=norm_list2)
+        plt.close()
+
+        norm_list3 = [None, colors.CenteredNorm(), colors.PowerNorm(gamma=0.5)]
+        isns.ImageGrid(self.img_list, norm=norm_list3)
+        plt.close()
+
+        with pytest.raises(AssertionError):
+            isns.ImageGrid(self.img_3d, norm=[colors.LogNorm(vmin=1e-4, vmax=1)])
             plt.close()
 
     def test_robust(self):


### PR DESCRIPTION
The default colormaps for rgbplot were from white to red/blue/green, and it didn't show each channel properly, i added the colormaps R, G and B that go from black to red/blue/green. To do so i created a new dictionary _CMAP_EXTRA because the class of colormap present in _CMAP_QUAL was not compatible with the one i was using, if this is a problem i have no problem changing it.

The code to register the new colormaps was using a deprecated matplotlib function and was using exceptions where an if statement could be used, that is fixed now.

Now the ImageGrid class accepts a norm parameter so that logarithmic color maps can be used, however, this is implemented so all images use the same normalization, it could be a good idea to change it, but i don't think it's that important.

All the tests pass and the coverage percent is exactly the same as before.