### PR TITLE
Update how figure is determined from supplied axis

### DIFF
--- a/src/seaborn_image/_core.py
+++ b/src/seaborn_image/_core.py
@@ -69,7 +69,7 @@ class _SetupImage(object):
         if self.ax is None:
             f, ax = plt.subplots()
         else:
-            f = plt.gcf()
+            f = self.ax.get_figure() or plt.gcf()
             ax = self.ax
 
         return f, ax


### PR DESCRIPTION
Earlier, when an `ax` was supplied, `plt.gcf()` was used to determine the figure. Now, this has been updated to use `ax.get_figure()` with `plt.gcf()` as backup.