### PR TITLE
Added support for the 'extent' argument in imgplot and other functions that can make use of it

### DIFF
--- a/src/seaborn_image/_core.py
+++ b/src/seaborn_image/_core.py
@@ -41,6 +41,7 @@ class _SetupImage(object):
         cbar_ticks=None,
         showticks=False,
         despine=None,
+        extent=None
     ):
 
         self.data = data
@@ -63,6 +64,7 @@ class _SetupImage(object):
         self.cbar_ticks = cbar_ticks
         self.showticks = showticks
         self.despine = despine
+        self.extent = extent
 
     def _setup_figure(self):
         """Wrapper to setup image with the desired parameters"""
@@ -135,6 +137,7 @@ class _SetupImage(object):
             alpha=self.alpha,
             interpolation=self.interpolation,
             norm=self.norm,
+            extent=self.extent
         )
 
         if self.dx:

--- a/src/seaborn_image/_filters.py
+++ b/src/seaborn_image/_filters.py
@@ -126,8 +126,9 @@ def filterplot(
         Show image x-y axis ticks, by default False
     despine : bool, optional
         Remove axes spines from image axes as well as colorbar axes, by default None
-    extent : list, optional
-        Coordinates where to plot this image.
+    extent : floats (left, right, bottom, top), optional
+        The bounding box in data coordinates that the image will fill.
+        The image is stretched individually along x and y to fill the box.
     **kwargs : optional
         Any additional parameters to be passed to the specific `filt` chosen.
         For instance, "sigma" or "size" or "mode" etc.

--- a/src/seaborn_image/_filters.py
+++ b/src/seaborn_image/_filters.py
@@ -52,6 +52,7 @@ def filterplot(
     cbar_ticks=None,
     showticks=False,
     despine=None,
+    extent=None,
     **kwargs,
 ):
     """
@@ -125,6 +126,8 @@ def filterplot(
         Show image x-y axis ticks, by default False
     despine : bool, optional
         Remove axes spines from image axes as well as colorbar axes, by default None
+    extent : list, optional
+        Coordinates where to plot this image.
     **kwargs : optional
         Any additional parameters to be passed to the specific `filt` chosen.
         For instance, "sigma" or "size" or "mode" etc.
@@ -225,6 +228,7 @@ def filterplot(
         cbar_ticks=cbar_ticks,
         showticks=showticks,
         despine=despine,
+        extent=extent
     )
 
     # Provide basic statistical results

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -39,6 +39,7 @@ def imgplot(
     cbar_ticks=None,
     showticks=False,
     despine=None,
+    extent=None,
     **kwargs,
 ):
     """Plot data as a 2-D image with options to ignore outliers, add scalebar, colorbar, title.
@@ -111,6 +112,8 @@ def imgplot(
         Show image x-y axis ticks, by default False
     despine : bool, optional
         Remove axes spines from image axes as well as colorbar axes, by default None
+    extent : list, optional
+        Coordinates where to plot this image.
 
     Returns
     -------
@@ -340,6 +343,7 @@ def imgplot(
         cbar_ticks=cbar_ticks,
         showticks=showticks,
         despine=despine,
+        extent=extent
     )
 
     f, ax, cax = img_plotter.plot()

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -112,8 +112,10 @@ def imgplot(
         Show image x-y axis ticks, by default False
     despine : bool, optional
         Remove axes spines from image axes as well as colorbar axes, by default None
-    extent : list, optional
-        Coordinates where to plot this image.
+    extent : floats (left, right, bottom, top), optional
+        The bounding box in data coordinates that the image will fill.
+        The image is stretched individually along x and y to fill the box.
+
 
     Returns
     -------

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -113,8 +113,9 @@ class ImageGrid:
     despine : bool, optional
         Remove axes spines from image axes as well as colorbar axes.
         Defaults to None.
-    extent : list, optional
-        Coordinates where to plot this image.
+    extent : floats (left, right, bottom, top), optional
+        The bounding box in data coordinates that the image will fill.
+        The image is stretched individually along x and y to fill the box.
 
     Returns
     -------
@@ -837,8 +838,9 @@ def rgbplot(
     despine : bool, optional
         Remove axes spines from image axes as well as colorbar axes.
         Defaults to None.
-    extent : list, optional
-        Coordinates where to plot this image.
+    extent : floats (left, right, bottom, top), optional
+        The bounding box in data coordinates that the image will fill.
+        The image is stretched individually along x and y to fill the box.
 
     Returns
     -------

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -113,6 +113,8 @@ class ImageGrid:
     despine : bool, optional
         Remove axes spines from image axes as well as colorbar axes.
         Defaults to None.
+    extent : list, optional
+        Coordinates where to plot this image.
 
     Returns
     -------
@@ -335,6 +337,7 @@ class ImageGrid:
         cbar_ticks=None,
         showticks=False,
         despine=None,
+        extent=None,
     ):
         if data is None:
             raise ValueError("image data can not be None")
@@ -473,6 +476,7 @@ class ImageGrid:
         self.cbar_ticks = cbar_ticks
         self.showticks = showticks
         self.despine = despine
+        self.extent = extent
 
         self._nrow = nrow
         self._ncol = ncol
@@ -624,6 +628,7 @@ class ImageGrid:
                 cbar_ticks=self.cbar_ticks,
                 showticks=self.showticks,
                 despine=self.despine,
+                extent=self.extent,
                 describe=False,
             )
 
@@ -764,6 +769,7 @@ def rgbplot(
     cbar_ticks=None,
     showticks=False,
     despine=None,
+    extent=None
 ):
     """Split and plot the red, green and blue channels of an
     RGB image.
@@ -831,6 +837,8 @@ def rgbplot(
     despine : bool, optional
         Remove axes spines from image axes as well as colorbar axes.
         Defaults to None.
+    extent : list, optional
+        Coordinates where to plot this image.
 
     Returns
     -------
@@ -915,6 +923,7 @@ def rgbplot(
         cbar_ticks=cbar_ticks,
         showticks=showticks,
         despine=despine,
+        extent=extent
     )
 
     return g
@@ -1002,6 +1011,8 @@ class ParamGrid(object):
     despine : bool, optional
         Remove axes spines from image axes as well as colorbar axes.
         Defaults to None.
+    extent : list, optional
+        Coordinates where to plot this image.
     **kwargs : Additional parameters as keyword arguments to be passed to the underlying filter specified.
 
     Returns
@@ -1106,6 +1117,7 @@ class ParamGrid(object):
         cbar_ticks=None,
         showticks=False,
         despine=None,
+        extent=None,
         **kwargs,
     ):
         if data is None:
@@ -1211,6 +1223,7 @@ class ParamGrid(object):
         self.cbar_ticks = cbar_ticks
         self.showticks = showticks
         self.despine = despine
+        self.extent = extent
 
         self._nrow = nrow
         self._ncol = ncol
@@ -1300,6 +1313,7 @@ class ParamGrid(object):
             cbar_ticks=self.cbar_ticks,
             showticks=self.showticks,
             despine=self.despine,
+            extent=self.extent,
             **func_kwargs,
         )
         return

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -167,6 +167,7 @@ def test_plot_w_all_inputs(
     showticks,
     despine,
     robust,
+    extent
 ):
     img_setup = isns._core._SetupImage(
         data,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -154,6 +154,7 @@ def test_data_plotted_is_same_as_input():
 @pytest.mark.parametrize("vmin", [None, 0])
 @pytest.mark.parametrize("vmax", [None, 1])
 @pytest.mark.parametrize("robust", [True, False])
+@pytest.mark.parametrize("extent", [(0,1,0,1), (20, 30, 0, 10)])
 def test_plot_w_all_inputs(
     cmap,
     vmin,
@@ -183,6 +184,7 @@ def test_plot_w_all_inputs(
         cbar_ticks=[],
         showticks=showticks,
         despine=despine,
+        extent=extent
     )
     f, ax, cax = img_setup.plot()
 

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -125,7 +125,7 @@ def test_imgplot_extent():
 @pytest.mark.parametrize("data", [data, astronaut()])
 @pytest.mark.parametrize("extent", [(0,1,0,1), (20, 30, 0, 10)])
 def test_gray_cmap_interplay(data, gray, cmap, extent):
-    _ = isns.imgplot(data, cmap=cmap, gray=gray)
+    _ = isns.imgplot(data, cmap=cmap, gray=gray, extent=extent)
     plt.close("all")
 
 

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -114,6 +114,7 @@ def test_imgplot_gray_conversion_for_rgb():
 @pytest.mark.parametrize("gray", [True, False])
 @pytest.mark.parametrize("cmap", [None, "ice"])
 @pytest.mark.parametrize("data", [data, astronaut()])
+@pytest.mark.parametrize("extent", [(0,1,0,1), (20, 30, 0, 10)])
 def test_gray_cmap_interplay(data, gray, cmap):
     _ = isns.imgplot(data, cmap=cmap, gray=gray)
     plt.close("all")

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -110,6 +110,15 @@ def test_imgplot_gray_conversion_for_rgb():
 
     np.testing.assert_array_equal(ax.images[0].get_array().data, rgb2gray(astronaut()))
 
+def test_imgplot_extent():
+    extent = (0,1,0,1)
+    ax = isns.imgplot(astronaut(), gray=True, extent=extent)
+    np.testing.assert_array_equal(ax.images[0].get_extent(), extent)
+
+    extent = (20, 30, 0, 10)
+    ax = isns.imgplot(astronaut(), gray=True, extent=extent)
+    np.testing.assert_array_equal(ax.images[0].get_extent(), extent)
+
 
 @pytest.mark.parametrize("gray", [True, False])
 @pytest.mark.parametrize("cmap", [None, "ice"])

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -115,7 +115,7 @@ def test_imgplot_gray_conversion_for_rgb():
 @pytest.mark.parametrize("cmap", [None, "ice"])
 @pytest.mark.parametrize("data", [data, astronaut()])
 @pytest.mark.parametrize("extent", [(0,1,0,1), (20, 30, 0, 10)])
-def test_gray_cmap_interplay(data, gray, cmap):
+def test_gray_cmap_interplay(data, gray, cmap, extent):
     _ = isns.imgplot(data, cmap=cmap, gray=gray)
     plt.close("all")
 


### PR DESCRIPTION
I added the ability for the user to specify the 'extent' argument in functions that display images so that they can specify the coordinates where this image will be located.

This is a somewhat niche argument in the implot function implemented in matplolib that lets you specify the location of the image, it is useful when you use the basemap extension to draw the coasts of the continents on top of, for example, a pressure map. This is necessary since basemap draws the lines at certain coordinates, but, unless specified otherwise, images of size (X, Y) will always be drawn from (0,0) to (X,Y).

To ilustrate this. This is how basemap works without using the extent argument:
```
import numpy as np
import matplotlib.pyplot as plt
from mpl_toolkits.basemap import Basemap
import seaborn_image as isns

fig, ax = plt.subplots(figsize = (15,8))

lat=(25, 72)
lon=(-60, 60)

m = Basemap(
    ax = ax,
    resolution = 'l',
    llcrnrlat = lat[0], llcrnrlon = lon[0],
    urcrnrlat = lat[1], urcrnrlon = lon[1],
    anchor=None,
)
countries = m.drawcountries(color='#303338')
coast = m.drawcoastlines(color='#000000')


isns.imgplot(np.random.random((63, 120))*0.5+0.5, vmin=0, vmax=1, ax=ax)

isns.despine()

plt.show()
```
![image](https://github.com/SarthakJariwala/seaborn-image/assets/46348947/7e3318a5-37c8-4558-9e64-e6b903befcaa)

And specifying the extent argument:
```
import numpy as np
import matplotlib.pyplot as plt
from mpl_toolkits.basemap import Basemap
import seaborn_image as isns

fig, ax = plt.subplots(figsize = (15,8))

lat=(25, 72)
lon=(-60, 60)

m = Basemap(
    ax = ax,
    resolution = 'l',
    llcrnrlat = lat[0], llcrnrlon = lon[0],
    urcrnrlat = lat[1], urcrnrlon = lon[1],
    anchor=None,
)
countries = m.drawcountries(color='#303338')
coast = m.drawcoastlines(color='#000000')


isns.imgplot(np.random.random((63, 120))*0.5+0.5, vmin=0, vmax=1, ax=ax, extent=[-60, 60, 25, 72])

isns.despine()

plt.show()
```
![image](https://github.com/SarthakJariwala/seaborn-image/assets/46348947/ad7b7d94-56e0-4136-b4ce-41089b1399aa)


