### PR TITLE
Diverging cmap

### DIFF
--- a/src/seaborn_image/_colormap.py
+++ b/src/seaborn_image/_colormap.py
@@ -60,7 +60,7 @@ _CMAP_QUAL = {
     "sunset": Sunset_7_r,
 }
 
- 
+
 # Extra color maps for various purposes like showing RGB channels of an image
 _CMAP_EXTRA = {
     "R": mpl.colors.LinearSegmentedColormap.from_list("R", ["#000000", "#FF0000"]),

--- a/src/seaborn_image/_context.py
+++ b/src/seaborn_image/_context.py
@@ -122,18 +122,17 @@ def set_image(cmap="deep", origin="upper", interpolation="nearest", despine=Fals
 
     """
 
-    # Load colormap from palletable 
+    # Load colormap from palletable
     if isinstance(cmap, str) and cmap in _CMAP_QUAL.keys():
         cmap_qual_mpl = _CMAP_QUAL.get(cmap).mpl_colormap
         if cmap not in mpl.colormaps.keys():
             mpl.colormaps.register(name=cmap, cmap=cmap_qual_mpl)
-    
+
     # Load extra colormap
     if isinstance(cmap, str) and cmap in _CMAP_EXTRA.keys():
         cmap_channel_mpl = _CMAP_EXTRA.get(cmap)
         if cmap not in mpl.colormaps.keys():
             mpl.colormaps.register(name=cmap, cmap=cmap_channel_mpl)
-        
 
     # change the axes spines
     # "not" is required because of the despine parameter name

--- a/src/seaborn_image/_core.py
+++ b/src/seaborn_image/_core.py
@@ -57,6 +57,7 @@ class _SetupImage(object):
         self.norm = norm
         self.robust = robust
         self.diverging = diverging
+        self.vmaxabs = vmaxabs
         self.perc = perc
         self.dx = dx
         self.units = units
@@ -128,7 +129,7 @@ class _SetupImage(object):
         if self.diverging: 
             # Force vmin to have the same absolute value as vmax so that 0 is in the middle.
 
-            if self.vmaxabs is not None: 
+            if self.vmaxabs is None: 
                 if self.vmin is None or self.vmax is None:
                     vmaxabs = np.abs(self.data).max()
                 else:

--- a/src/seaborn_image/_core.py
+++ b/src/seaborn_image/_core.py
@@ -32,6 +32,8 @@ class _SetupImage(object):
         norm=None,
         robust=False,
         perc=None,
+        diverging=False,
+        vmaxabs=None,
         dx=None,
         units=None,
         dimension=None,
@@ -54,6 +56,7 @@ class _SetupImage(object):
         self.interpolation = interpolation
         self.norm = norm
         self.robust = robust
+        self.diverging = diverging
         self.perc = perc
         self.dx = dx
         self.units = units
@@ -114,15 +117,27 @@ class _SetupImage(object):
             min_robust = False
             max_robust = False
             if self.vmin is None:
-                min_robust = (
-                    True  # remember that vmin was None and now set to new value
-                )
+                # remember that vmin was None and now set to new value
+                min_robust = True
                 self.vmin = np.nanpercentile(self.data, self.perc[0])
             if self.vmax is None:
-                max_robust = (
-                    True  # remember that vmax was None and now set to new value
-                )
+                # remember that vmax was None and now set to new value
+                max_robust = True 
                 self.vmax = np.nanpercentile(self.data, self.perc[1])
+        
+        if self.diverging: 
+            # Force vmin to have the same absolute value as vmax so that 0 is in the middle.
+
+            if self.vmaxabs is not None: 
+                if self.vmin is None or self.vmax is None:
+                    vmaxabs = np.abs(self.data).max()
+                else:
+                    vmaxabs = max(abs(self.vmin), abs(self.vmax))
+            else:
+                vmaxabs = self.vmaxabs
+
+            self.vmin = -vmaxabs
+            self.vmax = vmaxabs            
 
         if self.norm == "cbar_log":
             self.norm = colors.LogNorm(vmin=self.vmin, vmax=self.vmax)

--- a/src/seaborn_image/_core.py
+++ b/src/seaborn_image/_core.py
@@ -129,14 +129,14 @@ class _SetupImage(object):
 
             if self.vmax is None and self.vmin is None:
                 self.vmax = np.abs(self.data).max()
-                self.vmin = -np.abs(self.data).max()
+                self.vmin = -self.vmax
             elif self.vmax is None:
                 self.vmax = abs(self.vmin)
             elif self.vmin is None:
                 self.vmin = -abs(self.vmax)
             else:
                 self.vmax = max(abs(self.vmin), abs(self.vmax))
-                self.vmin = -max(abs(self.vmin), abs(self.vmax))
+                self.vmin = -self.vmax
 
         if self.norm == "cbar_log":
             self.norm = colors.LogNorm(vmin=self.vmin, vmax=self.vmax)

--- a/src/seaborn_image/_core.py
+++ b/src/seaborn_image/_core.py
@@ -33,7 +33,6 @@ class _SetupImage(object):
         robust=False,
         perc=None,
         diverging=False,
-        vmaxabs=None,
         dx=None,
         units=None,
         dimension=None,
@@ -57,7 +56,6 @@ class _SetupImage(object):
         self.norm = norm
         self.robust = robust
         self.diverging = diverging
-        self.vmaxabs = vmaxabs
         self.perc = perc
         self.dx = dx
         self.units = units
@@ -129,16 +127,16 @@ class _SetupImage(object):
         if self.diverging:
             # Force vmin to have the same absolute value as vmax so that 0 is in the middle.
 
-            if self.vmaxabs is None:
-                if self.vmin is None or self.vmax is None:
-                    vmaxabs = np.abs(self.data).max()
-                else:
-                    vmaxabs = max(abs(self.vmin), abs(self.vmax))
+            if self.vmax is None and self.vmin is None:
+                self.vmax = np.abs(self.data).max()
+                self.vmin = -np.abs(self.data).max()
+            elif self.vmax is None:
+                self.vmax = abs(self.vmin)
+            elif self.vmin is None:
+                self.vmin = -abs(self.vmax)
             else:
-                vmaxabs = self.vmaxabs
-
-            self.vmin = -vmaxabs
-            self.vmax = vmaxabs
+                self.vmax = max(abs(self.vmin), abs(self.vmax))
+                self.vmin = -max(abs(self.vmin), abs(self.vmax))
 
         if self.norm == "cbar_log":
             self.norm = colors.LogNorm(vmin=self.vmin, vmax=self.vmax)

--- a/src/seaborn_image/_core.py
+++ b/src/seaborn_image/_core.py
@@ -43,7 +43,7 @@ class _SetupImage(object):
         cbar_ticks=None,
         showticks=False,
         despine=None,
-        extent=None
+        extent=None,
     ):
 
         self.data = data
@@ -110,7 +110,7 @@ class _SetupImage(object):
 
         if isinstance(self.cmap, str) and self.cmap in _CMAP_QUAL.keys():
             self.cmap = _CMAP_QUAL.get(self.cmap).mpl_colormap
-        
+
         if isinstance(self.cmap, str) and self.cmap in _CMAP_EXTRA.keys():
             self.cmap = _CMAP_EXTRA.get(self.cmap)
 
@@ -123,13 +123,13 @@ class _SetupImage(object):
                 self.vmin = np.nanpercentile(self.data, self.perc[0])
             if self.vmax is None:
                 # remember that vmax was None and now set to new value
-                max_robust = True 
+                max_robust = True
                 self.vmax = np.nanpercentile(self.data, self.perc[1])
-        
-        if self.diverging: 
+
+        if self.diverging:
             # Force vmin to have the same absolute value as vmax so that 0 is in the middle.
 
-            if self.vmaxabs is None: 
+            if self.vmaxabs is None:
                 if self.vmin is None or self.vmax is None:
                     vmaxabs = np.abs(self.data).max()
                 else:
@@ -138,7 +138,7 @@ class _SetupImage(object):
                 vmaxabs = self.vmaxabs
 
             self.vmin = -vmaxabs
-            self.vmax = vmaxabs            
+            self.vmax = vmaxabs
 
         if self.norm == "cbar_log":
             self.norm = colors.LogNorm(vmin=self.vmin, vmax=self.vmax)
@@ -153,7 +153,7 @@ class _SetupImage(object):
             alpha=self.alpha,
             interpolation=self.interpolation,
             norm=self.norm,
-            extent=self.extent
+            extent=self.extent,
         )
 
         if self.dx:

--- a/src/seaborn_image/_filters.py
+++ b/src/seaborn_image/_filters.py
@@ -42,7 +42,6 @@ def filterplot(
     robust=False,
     perc=(2, 98),
     diverging=False,
-    vmaxabs=None,
     dx=None,
     units=None,
     dimension=None,
@@ -101,8 +100,6 @@ def filterplot(
     diverging : bool, optional
         If True, vmax and vmin are adjusted so they have the same absolute value, making the diverging
         color maps show 0 at the middle.
-    vmaxabs : float, optional
-        If `diverging` is True, sets vmax to vmaxabs and vmin to -vmaxabs.
     units : str, optional
         Units of `dx`, by default None
     dimension : str, optional
@@ -226,7 +223,6 @@ def filterplot(
         robust=robust,
         perc=perc,
         diverging=diverging,
-        vmaxabs=vmaxabs,
         dx=dx,
         units=units,
         dimension=dimension,

--- a/src/seaborn_image/_filters.py
+++ b/src/seaborn_image/_filters.py
@@ -102,7 +102,7 @@ def filterplot(
         If True, vmax and vmin are adjusted so they have the same absolute value, making the diverging
         color maps show 0 at the middle.
     vmaxabs : float, optional
-        If `diverging` is True, sets vmax to vmaxabs and vmin to -vmaxabs. 
+        If `diverging` is True, sets vmax to vmaxabs and vmin to -vmaxabs.
     units : str, optional
         Units of `dx`, by default None
     dimension : str, optional
@@ -238,7 +238,7 @@ def filterplot(
         cbar_ticks=cbar_ticks,
         showticks=showticks,
         despine=despine,
-        extent=extent
+        extent=extent,
     )
 
     # Provide basic statistical results

--- a/src/seaborn_image/_filters.py
+++ b/src/seaborn_image/_filters.py
@@ -41,6 +41,8 @@ def filterplot(
     interpolation=None,
     robust=False,
     perc=(2, 98),
+    diverging=False,
+    vmaxabs=None,
     dx=None,
     units=None,
     dimension=None,
@@ -96,6 +98,11 @@ def filterplot(
     dx : float, optional
         Size per pixel of the image data. Specifying `dx` and `units` adds a scalebar
         to the image, by default None
+    diverging : bool, optional
+        If True, vmax and vmin are adjusted so they have the same absolute value, making the diverging
+        color maps show 0 at the middle.
+    vmaxabs : float, optional
+        If `diverging` is True, sets vmax to vmaxabs and vmin to -vmaxabs. 
     units : str, optional
         Units of `dx`, by default None
     dimension : str, optional
@@ -218,6 +225,8 @@ def filterplot(
         interpolation=interpolation,
         robust=robust,
         perc=perc,
+        diverging=diverging,
+        vmaxabs=vmaxabs,
         dx=dx,
         units=units,
         dimension=dimension,

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -83,7 +83,7 @@ def imgplot(
         If True, vmax and vmin are adjusted so they have the same absolute value, making the diverging
         color maps show 0 at the middle.
     vmaxabs : float, optional
-        If `diverging` is True, sets vmax to vmaxabs and vmin to -vmaxabs. 
+        If `diverging` is True, sets vmax to vmaxabs and vmin to -vmaxabs.
     dx : float, optional
         Size per pixel of the image data. Specifying `dx` and `units` adds a scalebar
         to the image, by default None
@@ -287,10 +287,10 @@ def imgplot(
     if robust is True:
         assert len(perc) == 2
         assert perc[0] < perc[1]  # order should be (min, max)
-    
+
     if diverging:
         if vmaxabs is not None:
-            assert vmaxabs > 0 
+            assert vmaxabs > 0
 
     if not isinstance(cbar, bool):
         raise TypeError
@@ -358,7 +358,7 @@ def imgplot(
         cbar_ticks=cbar_ticks,
         showticks=showticks,
         despine=despine,
-        extent=extent
+        extent=extent,
     )
 
     f, ax, cax = img_plotter.plot()
@@ -454,7 +454,7 @@ def imghist(
         If True, vmax and vmin are adjusted so they have the same absolute value, making the diverging
         color maps show 0 at the middle.
     vmaxabs : float, optional
-        If `diverging` is True, sets vmax to vmaxabs and vmin to -vmaxabs. 
+        If `diverging` is True, sets vmax to vmaxabs and vmin to -vmaxabs.
     dx : float, optional
         Size per pixel of the image data. Specifying `dx` and `units` adds a scalebar
         to the image, by default None

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -28,7 +28,6 @@ def imgplot(
     robust=False,
     perc=(2, 98),
     diverging=False,
-    vmaxabs=None,
     dx=None,
     units=None,
     dimension=None,
@@ -82,8 +81,6 @@ def imgplot(
     diverging : bool, optional
         If True, vmax and vmin are adjusted so they have the same absolute value, making the diverging
         color maps show 0 at the middle.
-    vmaxabs : float, optional
-        If `diverging` is True, sets vmax to vmaxabs and vmin to -vmaxabs.
     dx : float, optional
         Size per pixel of the image data. Specifying `dx` and `units` adds a scalebar
         to the image, by default None
@@ -289,8 +286,11 @@ def imgplot(
         assert perc[0] < perc[1]  # order should be (min, max)
 
     if diverging:
-        if vmaxabs is not None:
-            assert vmaxabs > 0
+        if vmax is not None:
+            assert vmax > 0
+
+        if vmin is not None:
+            assert vmin < 0
 
     if not isinstance(cbar, bool):
         raise TypeError
@@ -348,7 +348,6 @@ def imgplot(
         robust=robust,
         perc=perc,
         diverging=diverging,
-        vmaxabs=vmaxabs,
         dx=dx,
         units=units,
         dimension=dimension,
@@ -395,9 +394,8 @@ def imghist(
     interpolation=None,
     norm=None,
     robust=False,
-    diverging=False,
-    vmaxabs=None,
     perc=(2, 98),
+    diverging=False,
     dx=None,
     units=None,
     dimension=None,
@@ -453,8 +451,6 @@ def imghist(
     diverging : bool, optional
         If True, vmax and vmin are adjusted so they have the same absolute value, making the diverging
         color maps show 0 at the middle.
-    vmaxabs : float, optional
-        If `diverging` is True, sets vmax to vmaxabs and vmin to -vmaxabs.
     dx : float, optional
         Size per pixel of the image data. Specifying `dx` and `units` adds a scalebar
         to the image, by default None
@@ -613,7 +609,6 @@ def imghist(
         robust=robust,
         perc=perc,
         diverging=diverging,
-        vmaxabs=vmaxabs,
         dx=dx,
         units=units,
         dimension=dimension,

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -27,6 +27,8 @@ def imgplot(
     norm=None,
     robust=False,
     perc=(2, 98),
+    diverging=False,
+    vmaxabs=None,
     dx=None,
     units=None,
     dimension=None,
@@ -77,6 +79,11 @@ def imgplot(
         If `robust` is True, colormap range is calculated based
         on the percentiles specified instead of the extremes, by default (2, 98) -
         2nd and 98th percentiles for min and max values
+    diverging : bool, optional
+        If True, vmax and vmin are adjusted so they have the same absolute value, making the diverging
+        color maps show 0 at the middle.
+    vmaxabs : float, optional
+        If `diverging` is True, sets vmax to vmaxabs and vmin to -vmaxabs. 
     dx : float, optional
         Size per pixel of the image data. Specifying `dx` and `units` adds a scalebar
         to the image, by default None
@@ -280,6 +287,10 @@ def imgplot(
     if robust is True:
         assert len(perc) == 2
         assert perc[0] < perc[1]  # order should be (min, max)
+    
+    if diverging:
+        if vmaxabs is not None:
+            assert vmaxabs > 0 
 
     if not isinstance(cbar, bool):
         raise TypeError
@@ -336,6 +347,8 @@ def imgplot(
         norm=norm,
         robust=robust,
         perc=perc,
+        diverging=diverging,
+        vmaxabs=vmaxabs,
         dx=dx,
         units=units,
         dimension=dimension,
@@ -382,6 +395,8 @@ def imghist(
     interpolation=None,
     norm=None,
     robust=False,
+    diverging=False,
+    vmaxabs=None,
     perc=(2, 98),
     dx=None,
     units=None,
@@ -435,6 +450,11 @@ def imghist(
         If `robust` is True, colormap range is calculated based
         on the percentiles specified instead of the extremes, by default (2, 98) -
         2nd and 98th percentiles for min and max values
+    diverging : bool, optional
+        If True, vmax and vmin are adjusted so they have the same absolute value, making the diverging
+        color maps show 0 at the middle.
+    vmaxabs : float, optional
+        If `diverging` is True, sets vmax to vmaxabs and vmin to -vmaxabs. 
     dx : float, optional
         Size per pixel of the image data. Specifying `dx` and `units` adds a scalebar
         to the image, by default None
@@ -592,6 +612,8 @@ def imghist(
         norm=norm,
         robust=robust,
         perc=perc,
+        diverging=diverging,
+        vmaxabs=vmaxabs,
         dx=dx,
         units=units,
         dimension=dimension,

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -208,6 +208,14 @@ def imgplot(
 
         >>> isns.imgplot(img_out, robust=True, perc=(0.5,99.5))
 
+    Rescale colormap using the `diverging` parameter
+
+    .. plot::
+        :context: close-figs
+
+        >>> img_standard = img - img.mean()
+        >>> isns.imgplot(img_standard, diverging=True, cmap="seismic")
+
     Map a function to transform input image
 
     .. plot::
@@ -287,10 +295,10 @@ def imgplot(
 
     if diverging:
         if vmax is not None:
-            assert vmax > 0
+            assert vmax > 0, "vmax must be greater than 0 when diverging=True"
 
         if vmin is not None:
-            assert vmin < 0
+            assert vmin < 0, "vmin must be lower than 0 when diverging=True"
 
     if not isinstance(cbar, bool):
         raise TypeError

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -57,6 +57,11 @@ class ImageGrid:
         on the percentiles specified instead of the extremes, by default (2, 98) -
         2nd and 98th percentiles for min and max values. Can be a list of tuples, if
         input data is a list of images
+    diverging : bool or list, optional
+        If True, vmax and vmin are adjusted so they have the same absolute value, making the diverging
+        color maps show 0 at the middle.
+    vmaxabs : float or list, optional
+        If `diverging` is True, sets vmax to vmaxabs and vmin to -vmaxabs. 
     alpha : float or array-like, optional
         `matplotlib.pyplot.imshow` alpha blending value from 0 (transparent) to 1 (opaque),
         by default None
@@ -322,6 +327,8 @@ class ImageGrid:
         cmap=None,
         robust=False,
         perc=(2, 98),
+        diverging=False,
+        vmaxabs=None,
         alpha=None,
         origin=None,
         vmin=None,
@@ -461,6 +468,8 @@ class ImageGrid:
         self.cmap = cmap
         self.robust = robust
         self.perc = perc
+        self.diverging = diverging
+        self.vmaxabs = vmaxabs
         self.alpha = alpha
         self.origin = origin
         self.vmin = vmin
@@ -528,6 +537,8 @@ class ImageGrid:
         _cmap = self.cmap
         _robust = self.robust
         _perc = self.perc
+        _diverging = self.diverging
+        _vmaxabs = self.vmaxabs
         _vmin = self.vmin
         _vmax = self.vmax
         _norm = self.norm
@@ -566,6 +577,10 @@ class ImageGrid:
             if isinstance(self.robust, (list, tuple)):
                 self._check_len_wrt_n_images(self.robust)
                 _robust = self.robust[i]
+            
+            if isinstance(self.diverging, (list, tuple)):
+                self._check_len_wrt_n_images(self.diverging)
+                _diverging = self.diverging[i]
 
             if isinstance(self.vmin, (list, tuple)):
                 self._check_len_wrt_n_images(self.vmin)
@@ -574,6 +589,10 @@ class ImageGrid:
             if isinstance(self.vmax, (list, tuple)):
                 self._check_len_wrt_n_images(self.vmax)
                 _vmax = self.vmax[i]
+            
+            if isinstance(self.vmaxabs, (list, tuple)):
+                self._check_len_wrt_n_images(self.vmaxabs)
+                _vmaxabs = self.vmaxabs[i]
 
             if isinstance(self.perc, (list)):
                 self._check_len_wrt_n_images(self.perc)
@@ -613,6 +632,8 @@ class ImageGrid:
                 cmap=_cmap,
                 robust=_robust,
                 perc=_perc,
+                diverging=_diverging,
+                vmaxabs=_vmaxabs,
                 vmin=_vmin,
                 vmax=_vmax,
                 alpha=self.alpha,

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -61,7 +61,7 @@ class ImageGrid:
         If True, vmax and vmin are adjusted so they have the same absolute value, making the diverging
         color maps show 0 at the middle.
     vmaxabs : float or list, optional
-        If `diverging` is True, sets vmax to vmaxabs and vmin to -vmaxabs. 
+        If `diverging` is True, sets vmax to vmaxabs and vmin to -vmaxabs.
     alpha : float or array-like, optional
         `matplotlib.pyplot.imshow` alpha blending value from 0 (transparent) to 1 (opaque),
         by default None
@@ -577,7 +577,7 @@ class ImageGrid:
             if isinstance(self.robust, (list, tuple)):
                 self._check_len_wrt_n_images(self.robust)
                 _robust = self.robust[i]
-            
+
             if isinstance(self.diverging, (list, tuple)):
                 self._check_len_wrt_n_images(self.diverging)
                 _diverging = self.diverging[i]
@@ -589,7 +589,7 @@ class ImageGrid:
             if isinstance(self.vmax, (list, tuple)):
                 self._check_len_wrt_n_images(self.vmax)
                 _vmax = self.vmax[i]
-            
+
             if isinstance(self.vmaxabs, (list, tuple)):
                 self._check_len_wrt_n_images(self.vmaxabs)
                 _vmaxabs = self.vmaxabs[i]
@@ -791,7 +791,7 @@ def rgbplot(
     cbar_ticks=None,
     showticks=False,
     despine=None,
-    extent=None
+    extent=None,
 ):
     """Split and plot the red, green and blue channels of an
     RGB image.
@@ -946,7 +946,7 @@ def rgbplot(
         cbar_ticks=cbar_ticks,
         showticks=showticks,
         despine=despine,
-        extent=extent
+        extent=extent,
     )
 
     return g

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -60,8 +60,6 @@ class ImageGrid:
     diverging : bool or list, optional
         If True, vmax and vmin are adjusted so they have the same absolute value, making the diverging
         color maps show 0 at the middle.
-    vmaxabs : float or list, optional
-        If `diverging` is True, sets vmax to vmaxabs and vmin to -vmaxabs.
     alpha : float or array-like, optional
         `matplotlib.pyplot.imshow` alpha blending value from 0 (transparent) to 1 (opaque),
         by default None
@@ -328,7 +326,6 @@ class ImageGrid:
         robust=False,
         perc=(2, 98),
         diverging=False,
-        vmaxabs=None,
         alpha=None,
         origin=None,
         vmin=None,
@@ -469,7 +466,6 @@ class ImageGrid:
         self.robust = robust
         self.perc = perc
         self.diverging = diverging
-        self.vmaxabs = vmaxabs
         self.alpha = alpha
         self.origin = origin
         self.vmin = vmin
@@ -538,7 +534,6 @@ class ImageGrid:
         _robust = self.robust
         _perc = self.perc
         _diverging = self.diverging
-        _vmaxabs = self.vmaxabs
         _vmin = self.vmin
         _vmax = self.vmax
         _norm = self.norm
@@ -590,10 +585,6 @@ class ImageGrid:
                 self._check_len_wrt_n_images(self.vmax)
                 _vmax = self.vmax[i]
 
-            if isinstance(self.vmaxabs, (list, tuple)):
-                self._check_len_wrt_n_images(self.vmaxabs)
-                _vmaxabs = self.vmaxabs[i]
-
             if isinstance(self.perc, (list)):
                 self._check_len_wrt_n_images(self.perc)
                 _perc = self.perc[i]
@@ -633,7 +624,6 @@ class ImageGrid:
                 robust=_robust,
                 perc=_perc,
                 diverging=_diverging,
-                vmaxabs=_vmaxabs,
                 vmin=_vmin,
                 vmax=_vmax,
                 alpha=self.alpha,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -79,27 +79,25 @@ def test_diverging_param():
     assert img_setup.vmax == np.abs(data).max()
     plt.close()
 
-    img_setup = isns._core._SetupImage(data, diverging=True, vmax=1)
+    vmax = 2.75
+    img_setup = isns._core._SetupImage(data, diverging=True, vmax=vmax)
     f, ax, cax = img_setup.plot()
-    assert img_setup.vmin == -img_setup.vmax
-    assert img_setup.vmax == np.abs(data).max()
+    assert img_setup.vmax == vmax
+    assert img_setup.vmin == -vmax
     plt.close()
 
     vmin = -3
-    vmax = 2.75
+    img_setup = isns._core._SetupImage(data, diverging=True, vmin=vmin)
+    f, ax, cax = img_setup.plot()
+    assert img_setup.vmax == -vmin
+    assert img_setup.vmin == vmin
+    plt.close()
+
     img_setup = isns._core._SetupImage(data, diverging=True, vmin=vmin, vmax=vmax)
     f, ax, cax = img_setup.plot()
     assert img_setup.vmin == -img_setup.vmax
     assert img_setup.vmax == max(abs(vmin), abs(vmax))
     assert img_setup.vmin == -max(abs(vmin), abs(vmax))
-    plt.close()
-
-    vmaxabs = 2
-    img_setup = isns._core._SetupImage(data, diverging=True, vmaxabs=vmaxabs)
-    f, ax, cax = img_setup.plot()
-    assert img_setup.vmin == -img_setup.vmax
-    assert img_setup.vmax == vmaxabs
-    assert img_setup.vmin == -vmaxabs
     plt.close()
 
 
@@ -186,7 +184,6 @@ def test_data_plotted_is_same_as_input():
 @pytest.mark.parametrize("vmax", [None, 1])
 @pytest.mark.parametrize("robust", [True, False])
 @pytest.mark.parametrize("diverging", [True, False])
-@pytest.mark.parametrize("vmaxabs", [None, 1])
 @pytest.mark.parametrize("extent", [(0, 1, 0, 1), (20, 30, 0, 10)])
 def test_plot_w_all_inputs(
     cmap,
@@ -201,7 +198,6 @@ def test_plot_w_all_inputs(
     despine,
     robust,
     diverging,
-    vmaxabs,
     extent,
 ):
     img_setup = isns._core._SetupImage(
@@ -212,7 +208,6 @@ def test_plot_w_all_inputs(
         robust=robust,
         perc=(2, 98),
         diverging=diverging,
-        vmaxabs=vmaxabs,
         dx=dx,
         units=units,
         dimension=dimension,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -72,6 +72,34 @@ def test_robust_param():
     plt.close()
 
 
+# TODO complete test
+def test_diverging_param():
+    # img_setup = isns._core._SetupImage(data, robust=True, perc=(2, 98))
+    # f, ax, cax = img_setup.plot()
+    # assert img_setup.vmin == np.nanpercentile(data, 2)
+    # assert img_setup.vmax == np.nanpercentile(data, 98)
+    # plt.close()
+
+    # img_setup = isns._core._SetupImage(data, robust=True, perc=(2, 98), vmin=0)
+    # f, ax, cax = img_setup.plot()
+    # assert img_setup.vmin == 0
+    # assert img_setup.vmax == np.nanpercentile(data, 98)
+    # plt.close()
+
+    # img_setup = isns._core._SetupImage(data, robust=True, perc=(2, 98), vmax=1)
+    # f, ax, cax = img_setup.plot()
+    # assert img_setup.vmin == np.nanpercentile(data, 2)
+    # assert img_setup.vmax == 1
+    # plt.close()
+
+    # img_setup = isns._core._SetupImage(data, robust=True, perc=(2, 98), vmin=0, vmax=1)
+    # f, ax, cax = img_setup.plot()
+    # assert img_setup.vmin == 0
+    # assert img_setup.vmax == 1
+    # plt.close()
+    pass
+
+
 def test_log_scale_cbar():
     img_setup = isns._core._SetupImage(data, norm="cbar_log")
     f, ax, cax = img_setup.plot()
@@ -154,6 +182,8 @@ def test_data_plotted_is_same_as_input():
 @pytest.mark.parametrize("vmin", [None, 0])
 @pytest.mark.parametrize("vmax", [None, 1])
 @pytest.mark.parametrize("robust", [True, False])
+@pytest.mark.parametrize("diverging", [True, False])
+@pytest.mark.parametrize("vmaxabs", [None, 1])
 @pytest.mark.parametrize("extent", [(0,1,0,1), (20, 30, 0, 10)])
 def test_plot_w_all_inputs(
     cmap,
@@ -167,6 +197,8 @@ def test_plot_w_all_inputs(
     showticks,
     despine,
     robust,
+    diverging,
+    vmaxabs,
     extent
 ):
     img_setup = isns._core._SetupImage(
@@ -176,6 +208,8 @@ def test_plot_w_all_inputs(
         vmax=None,
         robust=robust,
         perc=(2, 98),
+        diverging=diverging,
+        vmaxabs=vmaxabs,
         dx=dx,
         units=units,
         dimension=dimension,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -72,32 +72,35 @@ def test_robust_param():
     plt.close()
 
 
-# TODO complete test
 def test_diverging_param():
-    # img_setup = isns._core._SetupImage(data, robust=True, perc=(2, 98))
-    # f, ax, cax = img_setup.plot()
-    # assert img_setup.vmin == np.nanpercentile(data, 2)
-    # assert img_setup.vmax == np.nanpercentile(data, 98)
-    # plt.close()
+    img_setup = isns._core._SetupImage(data, diverging=True)
+    f, ax, cax = img_setup.plot()
+    assert img_setup.vmin == -img_setup.vmax
+    assert img_setup.vmax == np.abs(data).max()
+    plt.close()
 
-    # img_setup = isns._core._SetupImage(data, robust=True, perc=(2, 98), vmin=0)
-    # f, ax, cax = img_setup.plot()
-    # assert img_setup.vmin == 0
-    # assert img_setup.vmax == np.nanpercentile(data, 98)
-    # plt.close()
+    img_setup = isns._core._SetupImage(data, diverging=True, vmax=1)
+    f, ax, cax = img_setup.plot()
+    assert img_setup.vmin == -img_setup.vmax
+    assert img_setup.vmax == np.abs(data).max()
+    plt.close()
 
-    # img_setup = isns._core._SetupImage(data, robust=True, perc=(2, 98), vmax=1)
-    # f, ax, cax = img_setup.plot()
-    # assert img_setup.vmin == np.nanpercentile(data, 2)
-    # assert img_setup.vmax == 1
-    # plt.close()
+    vmin = -3
+    vmax = 2.75
+    img_setup = isns._core._SetupImage(data, diverging=True, vmin=vmin, vmax=vmax)
+    f, ax, cax = img_setup.plot()
+    assert img_setup.vmin == -img_setup.vmax
+    assert img_setup.vmax == max(abs(vmin), abs(vmax))
+    assert img_setup.vmin == -max(abs(vmin), abs(vmax))
+    plt.close()
 
-    # img_setup = isns._core._SetupImage(data, robust=True, perc=(2, 98), vmin=0, vmax=1)
-    # f, ax, cax = img_setup.plot()
-    # assert img_setup.vmin == 0
-    # assert img_setup.vmax == 1
-    # plt.close()
-    pass
+    vmaxabs = 2
+    img_setup = isns._core._SetupImage(data, diverging=True, vmaxabs=vmaxabs)
+    f, ax, cax = img_setup.plot()
+    assert img_setup.vmin == -img_setup.vmax
+    assert img_setup.vmax == vmaxabs
+    assert img_setup.vmin == -vmaxabs
+    plt.close()
 
 
 def test_log_scale_cbar():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -187,7 +187,7 @@ def test_data_plotted_is_same_as_input():
 @pytest.mark.parametrize("robust", [True, False])
 @pytest.mark.parametrize("diverging", [True, False])
 @pytest.mark.parametrize("vmaxabs", [None, 1])
-@pytest.mark.parametrize("extent", [(0,1,0,1), (20, 30, 0, 10)])
+@pytest.mark.parametrize("extent", [(0, 1, 0, 1), (20, 30, 0, 10)])
 def test_plot_w_all_inputs(
     cmap,
     vmin,
@@ -202,7 +202,7 @@ def test_plot_w_all_inputs(
     robust,
     diverging,
     vmaxabs,
-    extent
+    extent,
 ):
     img_setup = isns._core._SetupImage(
         data,
@@ -222,7 +222,7 @@ def test_plot_w_all_inputs(
         cbar_ticks=[],
         showticks=showticks,
         despine=despine,
-        extent=extent
+        extent=extent,
     )
     f, ax, cax = img_setup.plot()
 

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -35,6 +35,11 @@ def test_robust_type():
     with pytest.raises(TypeError):
         isns.imgplot(data, robust="True")
 
+def test_diverging_value():
+    with pytest.raises(AssertionError):
+        isns.imgplot(data, diverging=True, vmaxabs=-1)
+        plt.close()
+
 
 def test_vmaxabs():
     with pytest.raises(AssertionError):
@@ -246,30 +251,29 @@ def test_imghist_robust_hist_cmap():
     plt.close()
 
 
-# TODO complete test
 def test_imghist_diverging_hist_cmap():
     # """Check if the min/max patch color in histogram matches
-    # the min/max colors in the colorbar after robust"""
+    # the min/max colors in the colorbar after diverging"""
 
-    # polymer = isns.load_image("polymer")
+    polymer = isns.load_image("polymer")
+    polymer_norm = polymer - polymer.mean()
 
-    # f = isns.imghist(polymer, robust=True, perc=(0.5, 50))
+    f = isns.imghist(polymer_norm, diverging=True)
 
-    # _min = np.nanpercentile(polymer, 0.5)
-    # _max = np.nanpercentile(polymer, 50)
+    _min = -np.abs(polymer_norm).max()
+    _max = np.abs(polymer_norm).max()
 
     # # check the max patch facecolor and check it against the image cmap max
-    # np.testing.assert_array_equal(
-    #     f.axes[0].images[0].cmap(_max), f.axes[-1].patches[-1].get_facecolor()
-    # )
+    np.testing.assert_array_equal(
+        f.axes[0].images[0].cmap(_max), f.axes[-1].patches[-1].get_facecolor()
+    )
 
     # # check the min patch facecolor and check it against the image cmap min
-    # np.testing.assert_array_equal(
-    #     f.axes[0].images[0].cmap(_min), f.axes[-1].patches[0].get_facecolor()
-    # )
+    np.testing.assert_array_equal(
+        f.axes[0].images[0].cmap(_min), f.axes[-1].patches[0].get_facecolor()
+    )
 
-    # plt.close()
-    pass
+    plt.close()
 
 @pytest.mark.parametrize("cmap", [None, "acton"])
 @pytest.mark.parametrize("bins", [None, 100])

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -253,8 +253,8 @@ def test_imghist_robust_hist_cmap():
 
 
 def test_imghist_diverging_hist_cmap():
-    # """Check if the min/max patch color in histogram matches
-    # the min/max colors in the colorbar after diverging"""
+    """Check if the min/max patch color in histogram matches
+    the min/max colors in the colorbar after diverging"""
 
     polymer = isns.load_image("polymer")
     polymer_norm = polymer - polymer.mean()
@@ -264,12 +264,12 @@ def test_imghist_diverging_hist_cmap():
     _min = -np.abs(polymer_norm).max()
     _max = np.abs(polymer_norm).max()
 
-    # # check the max patch facecolor and check it against the image cmap max
+    # check the max patch facecolor and check it against the image cmap max
     np.testing.assert_array_equal(
         f.axes[0].images[0].cmap(_max), f.axes[-1].patches[-1].get_facecolor()
     )
 
-    # # check the min patch facecolor and check it against the image cmap min
+    # check the min patch facecolor and check it against the image cmap min
     np.testing.assert_array_equal(
         f.axes[0].images[0].cmap(_min), f.axes[-1].patches[0].get_facecolor()
     )

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -35,6 +35,7 @@ def test_robust_type():
     with pytest.raises(TypeError):
         isns.imgplot(data, robust="True")
 
+
 def test_diverging_value():
     with pytest.raises(AssertionError):
         isns.imgplot(data, diverging=True, vmaxabs=-1)
@@ -120,8 +121,9 @@ def test_imgplot_gray_conversion_for_rgb():
 
     np.testing.assert_array_equal(ax.images[0].get_array().data, rgb2gray(astronaut()))
 
+
 def test_imgplot_extent():
-    extent = (0,1,0,1)
+    extent = (0, 1, 0, 1)
     ax = isns.imgplot(astronaut(), gray=True, extent=extent)
     np.testing.assert_array_equal(ax.images[0].get_extent(), extent)
 
@@ -133,7 +135,7 @@ def test_imgplot_extent():
 @pytest.mark.parametrize("gray", [True, False])
 @pytest.mark.parametrize("cmap", [None, "ice"])
 @pytest.mark.parametrize("data", [data, astronaut()])
-@pytest.mark.parametrize("extent", [(0,1,0,1), (20, 30, 0, 10)])
+@pytest.mark.parametrize("extent", [(0, 1, 0, 1), (20, 30, 0, 10)])
 def test_gray_cmap_interplay(data, gray, cmap, extent):
     _ = isns.imgplot(data, cmap=cmap, gray=gray, extent=extent)
     plt.close("all")
@@ -274,6 +276,7 @@ def test_imghist_diverging_hist_cmap():
     )
 
     plt.close()
+
 
 @pytest.mark.parametrize("cmap", [None, "acton"])
 @pytest.mark.parametrize("bins", [None, 100])

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -36,6 +36,11 @@ def test_robust_type():
         isns.imgplot(data, robust="True")
 
 
+def test_vmaxabs():
+    with pytest.raises(AssertionError):
+        isns.imgplot(data, diverging=True, vmaxabs=-1)
+
+
 def test_map_func_type():
     with pytest.raises(TypeError):
         isns.imgplot(data, map_func="gaussian")
@@ -240,6 +245,31 @@ def test_imghist_robust_hist_cmap():
 
     plt.close()
 
+
+# TODO complete test
+def test_imghist_diverging_hist_cmap():
+    # """Check if the min/max patch color in histogram matches
+    # the min/max colors in the colorbar after robust"""
+
+    # polymer = isns.load_image("polymer")
+
+    # f = isns.imghist(polymer, robust=True, perc=(0.5, 50))
+
+    # _min = np.nanpercentile(polymer, 0.5)
+    # _max = np.nanpercentile(polymer, 50)
+
+    # # check the max patch facecolor and check it against the image cmap max
+    # np.testing.assert_array_equal(
+    #     f.axes[0].images[0].cmap(_max), f.axes[-1].patches[-1].get_facecolor()
+    # )
+
+    # # check the min patch facecolor and check it against the image cmap min
+    # np.testing.assert_array_equal(
+    #     f.axes[0].images[0].cmap(_min), f.axes[-1].patches[0].get_facecolor()
+    # )
+
+    # plt.close()
+    pass
 
 @pytest.mark.parametrize("cmap", [None, "acton"])
 @pytest.mark.parametrize("bins", [None, 100])

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -38,13 +38,12 @@ def test_robust_type():
 
 def test_diverging_value():
     with pytest.raises(AssertionError):
-        isns.imgplot(data, diverging=True, vmaxabs=-1)
+        isns.imgplot(data, diverging=True, vmax=-1)
         plt.close()
 
-
-def test_vmaxabs():
     with pytest.raises(AssertionError):
-        isns.imgplot(data, diverging=True, vmaxabs=-1)
+        isns.imgplot(data, diverging=True, vmin=1)
+        plt.close()
 
 
 def test_map_func_type():

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -716,7 +716,7 @@ class TestImageGrid:
         with pytest.raises(AssertionError):
             isns.ImageGrid(self.img_3d, perc=[(2, 98), (1, 99)])
             plt.close()
-    
+
     def test_diverging(self):
         isns.ImageGrid(self.img_list, diverging=True)
         plt.close()

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -717,33 +717,29 @@ class TestImageGrid:
             isns.ImageGrid(self.img_3d, perc=[(2, 98), (1, 99)])
             plt.close()
     
-    # TODO complete test
-    def test_robust(self):
-        # isns.ImageGrid(self.img_list, robust=True)
-        # plt.close()
+    def test_diverging(self):
+        isns.ImageGrid(self.img_list, diverging=True)
+        plt.close()
 
-        # isns.ImageGrid(self.img_list, robust=True, perc=[(2, 98), (1, 99), (2, 99)])
-        # plt.close()
+        isns.ImageGrid(self.img_list, diverging=True, vmaxabs=[1, 2, 1])
+        plt.close()
 
-        # isns.ImageGrid(
-        #     self.img_list, robust=[True, False, True], perc=[(2, 98), (1, 99), (2, 99)]
-        # )
-        # plt.close()
+        isns.ImageGrid(self.img_list, diverging=[True, False, True], vmaxabs=[1, 2, 1])
+        plt.close()
 
-        # isns.ImageGrid(self.img_3d, robust=True)
-        # plt.close()
+        isns.ImageGrid(self.img_3d, diverging=True)
+        plt.close()
 
-        # isns.ImageGrid([self.data], robust=True)
-        # plt.close()
+        isns.ImageGrid([self.data], diverging=True)
+        plt.close()
 
-        # with pytest.raises(AssertionError):
-        #     isns.ImageGrid(self.img_3d, robust=[True, False])
-        #     plt.close()
+        with pytest.raises(AssertionError):
+            isns.ImageGrid(self.img_3d, diverging=[True, False])
+            plt.close()
 
-        # with pytest.raises(AssertionError):
-        #     isns.ImageGrid(self.img_3d, perc=[(2, 98), (1, 99)])
-        #     plt.close()
-        pass
+        with pytest.raises(AssertionError):
+            isns.ImageGrid(self.img_3d, vmaxabs=[1, 2])
+            plt.close()
 
     def test_scalebar_list(self):
         isns.ImageGrid(

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -716,6 +716,34 @@ class TestImageGrid:
         with pytest.raises(AssertionError):
             isns.ImageGrid(self.img_3d, perc=[(2, 98), (1, 99)])
             plt.close()
+    
+    # TODO complete test
+    def test_robust(self):
+        # isns.ImageGrid(self.img_list, robust=True)
+        # plt.close()
+
+        # isns.ImageGrid(self.img_list, robust=True, perc=[(2, 98), (1, 99), (2, 99)])
+        # plt.close()
+
+        # isns.ImageGrid(
+        #     self.img_list, robust=[True, False, True], perc=[(2, 98), (1, 99), (2, 99)]
+        # )
+        # plt.close()
+
+        # isns.ImageGrid(self.img_3d, robust=True)
+        # plt.close()
+
+        # isns.ImageGrid([self.data], robust=True)
+        # plt.close()
+
+        # with pytest.raises(AssertionError):
+        #     isns.ImageGrid(self.img_3d, robust=[True, False])
+        #     plt.close()
+
+        # with pytest.raises(AssertionError):
+        #     isns.ImageGrid(self.img_3d, perc=[(2, 98), (1, 99)])
+        #     plt.close()
+        pass
 
     def test_scalebar_list(self):
         isns.ImageGrid(

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -721,10 +721,10 @@ class TestImageGrid:
         isns.ImageGrid(self.img_list, diverging=True)
         plt.close()
 
-        isns.ImageGrid(self.img_list, diverging=True, vmaxabs=[1, 2, 1])
+        isns.ImageGrid(self.img_list, diverging=True, vmax=[1, 2, 1])
         plt.close()
 
-        isns.ImageGrid(self.img_list, diverging=[True, False, True], vmaxabs=[1, 2, 1])
+        isns.ImageGrid(self.img_list, diverging=[True, False, True], vmax=[1, 2, 1])
         plt.close()
 
         isns.ImageGrid(self.img_3d, diverging=True)
@@ -735,10 +735,6 @@ class TestImageGrid:
 
         with pytest.raises(AssertionError):
             isns.ImageGrid(self.img_3d, diverging=[True, False])
-            plt.close()
-
-        with pytest.raises(AssertionError):
-            isns.ImageGrid(self.img_3d, vmaxabs=[1, 2])
             plt.close()
 
     def test_scalebar_list(self):


### PR DESCRIPTION
New arguments have been added called `diverging` and `vmaxabs`. They were added to the following functions: `_SetupImage`, `imgplot`, `imghist`, `filterplot` and `ImageGrid`.

The argument `diverging` forces vmin to be equal to -vmax, ensuring that diverging colormaps are displayed correctly, mapping the middle value to 0. The argument `vmaxabs` sets vmax to vmaxabs and vmin to -vmaxabs.

I added documentation and unit tests to everything that was needed.  

This implements the features discussed in issue #697.