### PR TITLE
Solved issues with documentation when using the CIFAR10 dataset

### DIFF
--- a/examples/plot_ImageGrid_3d_list.py
+++ b/examples/plot_ImageGrid_3d_list.py
@@ -5,6 +5,8 @@ List of 3D images
 
 import seaborn_image as isns
 
+isns.set_image(origin="lower")
+
 cifar_list = isns.load_image("cifar10 list")
 
 g = isns.ImageGrid(cifar_list, cbar=False, height=1, col_wrap=10)

--- a/examples/plot_ImageGrid_4d.py
+++ b/examples/plot_ImageGrid_4d.py
@@ -5,6 +5,8 @@
 
 import seaborn_image as isns
 
+isns.set_image(origin="lower")
+
 cifar = isns.load_image("cifar10")
 
 g = isns.ImageGrid(cifar, cbar=False, height=1, col_wrap=10)

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -240,7 +240,7 @@ class ImageGrid:
         :context: close-figs
 
         >>> cifar = isns.load_image("cifar10")
-        >>> g = isns.ImageGrid(cifar, height=1, col_wrap=6)
+        >>> g = isns.ImageGrid(cifar, height=1, col_wrap=6, origin="lower")
 
     Map a function to the image data
 


### PR DESCRIPTION
There were some issue in parts of the documentation when the sample from the CIFAR10 dataset was used. The images were flipped and an example of applying a function to the images was broken. It has been fixed by setting `origin="lower"` before displaying the images.