### PR TITLE
Update setup Python action for macOS 14 compatibility

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v5.1.1
       with:
         python-version: '3.10'
         architecture: x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v5.1.1
       with:
         python-version: '3.10'
         architecture: x64

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,11 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - { python-version: "3.11", os: ubuntu-latest }
           - { python-version: "3.10", os: ubuntu-latest }
           - { python-version: "3.9", os: ubuntu-latest }
           - { python-version: "3.8", os: ubuntu-latest }
-          - { python-version: "3.10", os: windows-latest }
-          - { python-version: "3.10", os: macos-latest }
+          - { python-version: "3.11", os: windows-latest }
+          - { python-version: "3.11", os: macos-latest }
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5.1.1
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/noxfile.py
+++ b/noxfile.py
@@ -22,7 +22,7 @@ except ImportError:
 
 
 package = "seaborn_image"
-python_versions = ["3.10", "3.9", "3.8"]
+python_versions = ["3.11", "3.10", "3.9", "3.8"]
 nox.needs_version = ">= 2021.6.6"
 locations = "src", "tests", "noxfile.py", "docs/conf.py", "examples"
 nox.options.sessions = "tests", "xdoctest"


### PR DESCRIPTION
setup-Python action on MacOS was broken after macOS latest moved to use macOS 14. 

Setup Python v5.1.1 fixes the issue