### PR TITLE
ci: add uv audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,15 @@
+name: Audit
+on:
+  - push
+  - pull_request
+jobs:
+  audit:
+    name: uv audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v10.0.1
+        with:
+          version: "0.12.10"
+          enable-cache: true
+      - run: uv audit --frozen --preview-features audit-command


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The packaging PR switches install and CI to uv and commits `uv.lock`. Nothing yet fails a PR when that lockfile contains a known-vulnerable dependency. Poetry-era `safety` was dropped with Nox and was not replaced.

## Scope

Stacked on #876 (`cursor/uv-packaging-791d`), not on `master` alone.

Adds `.github/workflows/audit.yml`. One Ubuntu job on `push` and `pull_request`. Reuses `astral-sh/setup-uv@v10.0.1` and the committed `uv.lock`. No test matrix. No Poetry or Nox.

CI command:

```
uv audit --frozen --preview-features audit-command
```

`uv audit` is experimental in uv 0.12. This workflow pins `version: "0.12.10"` on `setup-uv` so the command exists and the flag set stays stable. `--frozen` audits the lockfile without re-locking and errors if `uv.lock` is missing. `--preview-features audit-command` only silences the experimental warning. Default uv behavior is used for the gate: all extras and groups are audited, and the process exits non-zero on known vulnerabilities or adverse project statuses. No `--ignore`.

Out of scope: malware checks on `uv sync` (`UV_MALWARE_CHECK`), SARIF upload, lockfile upgrades, library code.

## Tradeoffs

`--frozen` is the lockfile-as-source-of-truth flag. `--locked` would also fail if `pyproject.toml` and `uv.lock` drifted. Tests already run `uv sync --locked`, so the audit job stays on `--frozen` and skips a second resolve.

Pinning uv 0.12.10 in this workflow only. Tests and coverage still take whatever `setup-uv@v10.0.1` installs. When `uv audit` leaves preview, the pin and `--preview-features` flag can drop.

OSV outages or new advisories on existing pins will fail this job. That is the intended gate.

## Blast Radius

CI-only. Library sources, `pyproject.toml`, and `uv.lock` are unchanged. Contributors who do not run GitHub Actions see no new local command unless they run `uv audit` themselves.

A vulnerable transitive pin will fail every PR and push until the lockfile is upgraded or an `--ignore` is added (not done here).

## Verification

Agent environment, uv 0.12.10. Same command CI runs:

```
uv audit --frozen --preview-features audit-command
```

On this repo's `uv.lock`:

```
Found no known vulnerabilities and no adverse project statuses in 106 packages
```

Exit 0.

Gate check (throwaway project, not committed). `jinja2==2.10` under the same flags:

```
Found 12 known vulnerabilities and no adverse project statuses in 2 packages
```

Exit 1. CI is left in the real fail-on-vuln mode with no `--ignore`.

GitHub Actions on this PR (uv 0.12.10 from `setup-uv`):

- Push job: https://github.com/SarthakJariwala/seaborn-image/actions/runs/33980487114 (`uv audit` success in 7s)
- Pull request job: https://github.com/SarthakJariwala/seaborn-image/actions/runs/33980506911 (`uv audit` success)

Both printed `Found no known vulnerabilities and no adverse project statuses in 106 packages`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90d9c55b-6e7d-4c1f-9d0e-33ef88d1791d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90d9c55b-6e7d-4c1f-9d0e-33ef88d1791d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

