### PR TITLE
Add explicit gap spacing to ImageGrid

### DIFF
--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -45,6 +45,16 @@ class ImageGrid:
         Size of the individual images. Defaults to 3.
     aspect : int, float or 'auto', optional
         Aspect ratio of individual images, when set to 'auto', it calculates the aspect ratio of the images passed. Defaults to 'auto'.
+    gap : float or None, optional
+        Space between images in inches. None preserves automatic layout. A
+        nonnegative value creates a montage without outer margins; 0 makes
+        images touch. Requires cbar=False, showticks=False, and matching
+        displayed image proportions. Uses height and the plotted proportions
+        instead of aspect to size the figure. Spacing applies at the initial
+        figure size; resizing or subsequent layout calls may change it.
+        Explicit spacing disables automatic figure layout, overriding the
+        corresponding Matplotlib rcParams.
+        Use fig.savefig(..., pad_inches=0) to omit export padding as well.
     cmap : str or `matplotlib.colors.Colormap` or list, optional
         Image colormap. If input data is a list of images,
         `cmap` can be a list of colormaps. Defaults to None.
@@ -323,6 +333,7 @@ class ImageGrid:
         col_wrap=None,
         height=3,
         aspect="auto",
+        gap=None,
         cmap=None,
         robust=False,
         perc=(2, 98),
@@ -347,6 +358,14 @@ class ImageGrid:
     ):
         if data is None:
             raise ValueError("image data can not be None")
+
+        if gap is not None:
+            if not isinstance(gap, (int, float, np.integer, np.floating)):
+                raise ValueError("gap must be a finite nonnegative number or None")
+            if not np.isfinite(gap) or gap < 0:
+                raise ValueError("gap must be a finite nonnegative number or None")
+            if np.any(cbar) or showticks:
+                raise ValueError("gap requires cbar=False and showticks=False")
 
         if isinstance(
             data, (list, tuple)
@@ -460,7 +479,7 @@ class ImageGrid:
         # Calculate the base figure size
         figsize = (ncol * height * aspect, nrow * height)
 
-        fig = plt.figure(figsize=figsize)
+        fig = plt.figure(figsize=figsize, layout="none" if gap is not None else None)
         axes = fig.subplots(nrow, ncol, squeeze=False)
 
         # Public API
@@ -475,6 +494,7 @@ class ImageGrid:
         self.col_wrap = col_wrap
         self.height = height
         self.aspect = aspect
+        self.gap = gap
 
         self.cmap = cmap
         self.robust = robust
@@ -770,8 +790,38 @@ class ImageGrid:
                 despine(ax=rem_ax[i])  # remove axes spines for the extra generated axes
 
     def _finalize_grid(self):
-        """Finalize grid with tight layout."""
-        self.fig.tight_layout()
+        """Apply automatic layout or explicit image spacing."""
+        if self.gap is None:
+            self.fig.tight_layout()
+            return
+
+        # Use plotted limits, not input shapes: extent and map_func can change
+        # the geometry. Equal slots cannot tightly tile differing proportions.
+        axes = list(self.axes.flat)[: self._nimages]
+        ratios = [
+            (
+                1 / (ax.get_data_ratio() * ax.get_aspect())
+                if ax.get_aspect() != "auto"
+                else self.aspect
+            )
+            for ax in axes
+        ]
+        if not np.allclose(ratios, ratios[0], rtol=1e-10, atol=0):
+            plt.close(self.fig)
+            raise ValueError("gap requires matching displayed image proportions")
+        width = self.height * ratios[0]
+        self.fig.set_size_inches(
+            self._ncol * width + (self._ncol - 1) * self.gap,
+            self._nrow * self.height + (self._nrow - 1) * self.gap,
+        )
+        self.fig.subplots_adjust(
+            left=0,
+            right=1,
+            bottom=0,
+            top=1,
+            wspace=self.gap / width,
+            hspace=self.gap / self.height,
+        )
 
 
 def rgbplot(

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1158,6 +1158,140 @@ class TestParamGrid(object):
         plt.close()
 
 
+@pytest.mark.parametrize("shape", [(20, 20), (20, 40), (40, 20)])
+@pytest.mark.parametrize("gap", [0, 0.15])
+@pytest.mark.parametrize("count,wrap", [(6, 3), (5, 3), (3, 1), (1, 1)])
+def test_image_grid_gap(shape, gap, count, wrap):
+    g = isns.ImageGrid(
+        [np.ones(shape)] * count,
+        cbar=False,
+        gap=gap,
+        col_wrap=wrap,
+    )
+    try:
+        g.fig.canvas.draw()
+        boxes = [ax.get_window_extent() for ax in g.axes.flat][:count]
+        for i, box in enumerate(boxes):
+            assert box.width / box.height == pytest.approx(shape[1] / shape[0])
+            if i % wrap:
+                assert box.x0 - boxes[i - 1].x1 == pytest.approx(
+                    gap * g.fig.dpi,
+                    abs=1e-8,
+                )
+            if i >= wrap:
+                assert boxes[i - wrap].y0 - box.y1 == pytest.approx(
+                    gap * g.fig.dpi,
+                    abs=1e-8,
+                )
+        assert boxes[0].x0 == pytest.approx(0, abs=1e-8)
+        assert boxes[0].y1 == pytest.approx(g.fig.bbox.height)
+    finally:
+        plt.close(g.fig)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"extent": (0, 80, 0, 20)},
+        {"map_func": lambda image: image[:, :10]},
+    ],
+)
+def test_image_grid_gap_uses_plotted_geometry(kwargs):
+    g = isns.ImageGrid(
+        [np.ones((20, 40))] * 4,
+        cbar=False,
+        gap=0,
+        col_wrap=2,
+        **kwargs,
+    )
+    try:
+        g.fig.canvas.draw()
+        a, b, c, _ = [ax.get_window_extent() for ax in g.axes.flat]
+        assert b.x0 - a.x1 == pytest.approx(0, abs=1e-8)
+        assert a.y0 - c.y1 == pytest.approx(0, abs=1e-8)
+    finally:
+        plt.close(g.fig)
+
+
+@pytest.mark.parametrize("gap", [-1, np.nan, np.inf, "auto", [0], 1j])
+def test_image_grid_invalid_gap(gap):
+    with pytest.raises(ValueError, match="gap must be"):
+        isns.ImageGrid([np.ones((20, 40))], cbar=False, gap=gap)
+
+
+@pytest.mark.parametrize("kwargs", [{}, {"cbar": False, "showticks": True}])
+def test_image_grid_gap_rejects_decorations(kwargs):
+    with pytest.raises(ValueError, match="gap requires cbar=False"):
+        isns.ImageGrid([np.ones((20, 40))], gap=0, **kwargs)
+
+
+def test_image_grid_gap_rejects_mixed_proportions():
+    figures = plt.get_fignums()
+    with pytest.raises(ValueError, match="matching displayed image proportions"):
+        isns.ImageGrid([np.ones((20, 40)), np.ones((40, 20))], cbar=False, gap=0)
+    assert plt.get_fignums() == figures
+
+
+@pytest.mark.parametrize(
+    "auto,constrained", [(True, False), (False, True), (True, True)]
+)
+@pytest.mark.parametrize("gap", [0, 0.15])
+def test_image_grid_gap_overrides_layout_defaults(auto, constrained, gap):
+    settings = {
+        "figure.autolayout": auto,
+        "figure.constrained_layout.use": constrained,
+    }
+    with matplotlib.rc_context(settings), warnings.catch_warnings():
+        warnings.simplefilter("error")
+        g = isns.ImageGrid(
+            [np.ones((20, 40))] * 5,
+            height=1,
+            col_wrap=3,
+            cbar=False,
+            gap=gap,
+        )
+        try:
+            assert g.fig.get_layout_engine() is None
+            np.testing.assert_allclose(g.fig.get_size_inches(), (6 + 2 * gap, 2 + gap))
+            for _ in range(2):
+                g.fig.canvas.draw()
+                a, b, c, d, e = [ax.get_window_extent() for ax in g.axes.flat][:5]
+                assert b.x0 - a.x1 == pytest.approx(gap * g.fig.dpi, abs=1e-8)
+                assert a.y0 - d.y1 == pytest.approx(gap * g.fig.dpi, abs=1e-8)
+                assert a.x0 == pytest.approx(0, abs=1e-8)
+                assert e.y0 == pytest.approx(0, abs=1e-8)
+                assert c.x1 == pytest.approx(g.fig.bbox.width)
+                assert a.y1 == pytest.approx(g.fig.bbox.height)
+            for key, value in settings.items():
+                assert matplotlib.rcParams[key] == value
+        finally:
+            plt.close(g.fig)
+
+
+@pytest.mark.parametrize(
+    "auto,constrained", [(True, False), (False, True), (True, True)]
+)
+@pytest.mark.parametrize("kwargs", [{}, {"gap": None}])
+def test_image_grid_default_retains_layout(auto, constrained, kwargs, monkeypatch):
+    engines = []
+    tight_layout = Figure.tight_layout
+
+    def record_layout(fig, *args, **kw):
+        engines.append(type(fig.get_layout_engine()).__name__)
+        return tight_layout(fig, *args, **kw)
+
+    monkeypatch.setattr(Figure, "tight_layout", record_layout)
+    with matplotlib.rc_context(
+        {
+            "figure.autolayout": auto,
+            "figure.constrained_layout.use": constrained,
+        }
+    ):
+        g = isns.ImageGrid([np.ones((20, 40))] * 2, cbar=False, **kwargs)
+        plt.close(g.fig)
+    assert engines == ["TightLayoutEngine" if auto else "ConstrainedLayoutEngine"]
+
+
 def test_FilterGrid_deprecation_warning():
     with pytest.warns(UserWarning, match="FilterGrid is depracted"):
         _ = isns.FilterGrid(


### PR DESCRIPTION
## Summary
- Add opt-in gap spacing in inches, including gap=0 for touching images.
- Preserve plotted image proportions and legacy automatic layout when gap is omitted.
- Validate unsupported decorations and mixed proportions; document export padding and resize limitations.
- Disable competing automatic layout engines for explicit spacing.

Addresses #630; complements #732 and #733.

## Verification
- MPLBACKEND=Agg uv run pytest -q: 9641 passed (3 warnings).
- Drawn-boundary coverage for square/non-square images, positive/zero gaps, transformations, extents, incomplete rows, and layout rcParams.
- Inspected rendered zero-gap and positive-gap exports.
- Oracle reviewed layout-engine ownership; its identified conflict was fixed with regression coverage.