### PR TITLE
Add shared colorbars to ImageGrid

### DIFF
--- a/examples/plot_ImageGrid_shared_colorbar.py
+++ b/examples/plot_ImageGrid_shared_colorbar.py
@@ -1,0 +1,33 @@
+"""
+ImageGrid: A shared color scale and colorbar
+==========================================
+
+A shared colorbar uses the same value-to-color mapping for every scalar image.
+Limits are calculated from the selected images, after any transformations.
+Use this when the images measure the same quantity in the same units.
+"""
+
+import seaborn_image as isns
+
+cells = isns.load_image("cells")
+
+# Automatic spacing with a single colorbar on the right.
+g = isns.ImageGrid(
+    cells, slices=[0, 10, 20, 30, 40, 50], cbar="shared", cbar_label="Intensity"
+)
+
+# %%
+# Touching images with a shared colorbar below. The bar does not shrink the
+# images or change their spacing. Robust limits use pooled pixel percentiles.
+g = isns.ImageGrid(
+    cells,
+    slices=[0, 10, 20, 30, 40, 50],
+    gap=0,
+    cbar="shared",
+    orientation="h",
+    cbar_label="Intensity",
+    robust=True,
+)
+
+# For exports without additional padding:
+# g.fig.savefig("cells.png", pad_inches=0)

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -3,6 +3,7 @@ import warnings
 from typing import Iterable
 
 import matplotlib.pyplot as plt
+from matplotlib.colors import LogNorm, Normalize
 import numpy as np
 from copy import copy
 
@@ -48,7 +49,7 @@ class ImageGrid:
     gap : float or None, optional
         Space between images in inches. None preserves automatic layout. A
         nonnegative value creates a montage without outer margins; 0 makes
-        images touch. Requires cbar=False, showticks=False, and matching
+        images touch. Requires cbar=False or 'shared', showticks=False, and matching
         displayed image proportions. Uses height and the plotted proportions
         instead of aspect to size the figure. Spacing applies at the initial
         figure size; resizing or subsequent layout calls may change it.
@@ -103,10 +104,17 @@ class ImageGrid:
             - "pixel" : scale bar showing px, kpx, Mpx, etc.
         Can be a list of str, if input data is a list of images.
         Defaults to None.
-    cbar : bool or list, optional
+    cbar : bool, list or 'shared', optional
         Specify if a colorbar is required or not.
         Can be a list of bools, if input data is a list of images.
-        Defaults to True.
+        Defaults to True. 'shared' creates one colorbar for all scalar images,
+        using one colormap and normalization over the selected, transformed
+        images. Automatic limits use all finite, unmasked values; robust=True
+        uses pooled percentiles. Per-image color settings and RGB/RGBA images
+        are not supported in shared mode. A supplied Normalize is autoscaled
+        over all images and cannot be combined with vmin/vmax, robust or
+        diverging. Shared colorbars work with or without explicit gap spacing.
+        The resulting colorbar and axes are available as colorbar and cbar_ax.
     orientation : str, optional
         Specify the orientaion of colorbar.
         Option include :
@@ -359,13 +367,46 @@ class ImageGrid:
         if data is None:
             raise ValueError("image data can not be None")
 
+        shared = isinstance(cbar, str) and cbar == "shared"
+        if isinstance(cbar, str) and not shared:
+            raise ValueError("cbar must be a bool, a list of bools, or 'shared'")
+        if shared:
+            for name, value in dict(
+                cmap=cmap,
+                norm=norm,
+                vmin=vmin,
+                vmax=vmax,
+                robust=robust,
+                diverging=diverging,
+                cbar_log=cbar_log,
+                cbar_label=cbar_label,
+            ).items():
+                if isinstance(value, (list, tuple, np.ndarray)):
+                    raise ValueError(f"shared colorbar requires a single {name}")
+            if np.shape(perc) != (2,):
+                raise ValueError("shared colorbar requires one percentile pair")
+            if norm is not None and (
+                not isinstance(norm, Normalize)
+                or vmin is not None
+                or vmax is not None
+                or robust
+                or diverging
+            ):
+                raise ValueError(
+                    "shared norm must be a Normalize without vmin/vmax, robust or diverging"
+                )
+            if orientation not in ("v", "vertical", "h", "horizontal"):
+                raise ValueError(
+                    "orientation must be vertical ('v') or horizontal ('h')"
+                )
+
         if gap is not None:
             if not isinstance(gap, (int, float, np.integer, np.floating)):
                 raise ValueError("gap must be a finite nonnegative number or None")
             if not np.isfinite(gap) or gap < 0:
                 raise ValueError("gap must be a finite nonnegative number or None")
-            if np.any(cbar) or showticks:
-                raise ValueError("gap requires cbar=False and showticks=False")
+            if (not shared and np.any(cbar)) or showticks:
+                raise ValueError("gap requires cbar=False or 'shared' and showticks=False")
 
         if isinstance(
             data, (list, tuple)
@@ -510,6 +551,9 @@ class ImageGrid:
         self.units = units
         self.dimension = dimension
         self.cbar = cbar
+        self._shared_cbar = shared
+        self.colorbar = None
+        self.cbar_ax = None
         self.orientation = orientation
         self.cbar_log = cbar_log
         self.cbar_label = cbar_label
@@ -527,8 +571,20 @@ class ImageGrid:
             self._map_func_to_data(map_func, map_func_kw)
 
         self._map_img_to_grid()
+        if self._shared_cbar:
+            try:
+                self._normalize_shared_images()
+            except ValueError:
+                plt.close(self.fig)
+                raise
         self._cleanup_extra_axes()
         self._finalize_grid()
+        if self._shared_cbar:
+            try:
+                self._add_shared_colorbar()
+            except ValueError:
+                plt.close(self.fig)
+                raise
 
     def _check_map_func(self, map_func, map_func_kw):
         "Check if `map_func` passed is a list/tuple of callables or individual callable"
@@ -599,6 +655,10 @@ class ImageGrid:
             else:
                 _d = self.data.take(indices=self.slices[i], axis=self.axis)
 
+            if self._shared_cbar and _d.ndim == 3 and _d.shape[-1] in (3, 4):
+                plt.close(self.fig)
+                raise ValueError("shared colorbar requires scalar images, not RGB/RGBA")
+
             if isinstance(self.cmap, (list, tuple)):
                 self._check_len_wrt_n_images(self.cmap)
                 _cmap = self.cmap[i]
@@ -655,21 +715,21 @@ class ImageGrid:
                 _d,
                 ax=ax,
                 cmap=_cmap,
-                robust=_robust,
+                robust=False if self._shared_cbar else _robust,
                 perc=_perc,
-                diverging=_diverging,
-                vmin=_vmin,
-                vmax=_vmax,
+                diverging=False if self._shared_cbar else _diverging,
+                vmin=None if self._shared_cbar else _vmin,
+                vmax=None if self._shared_cbar else _vmax,
                 alpha=self.alpha,
                 origin=self.origin,
                 interpolation=self.interpolation,
-                norm=_norm,
+                norm=None if self._shared_cbar else _norm,
                 dx=_dx,
                 units=_units,
                 dimension=_dimension,
-                cbar=_cbar,
+                cbar=False if self._shared_cbar else _cbar,
                 orientation=self.orientation,
-                cbar_log=_cbar_log,
+                cbar_log=False if self._shared_cbar else _cbar_log,
                 cbar_label=_cbar_label,
                 cbar_ticks=self.cbar_ticks,
                 showticks=self.showticks,
@@ -678,10 +738,116 @@ class ImageGrid:
                 describe=False,
             )
 
-        # FIXME - for common colorbar
-        # if self.cbar and self.vmin is not None and self.vmax is not None:
-        #     print("here")
-        #     self.fig.colorbar(_im.images[0], ax=list(self.axes.ravel()), orientation=self.orientation)
+    def _normalize_shared_images(self):
+        """Resolve one mapping from the scalar arrays actually plotted."""
+        images = [ax.images[0] for ax in list(self.axes.flat)[: self._nimages]]
+        values = np.ma.concatenate(
+            [im.get_array().ravel() for im in images]
+        ).compressed()
+        values = values[np.isfinite(values)]
+        if not values.size:
+            raise ValueError("shared colorbar requires finite, unmasked data")
+        norm = self.norm
+        if norm is None:
+            low, high = self.vmin, self.vmax
+            if self.robust:
+                limits = np.percentile(values, self.perc)
+                low = limits[0] if low is None else low
+                high = limits[1] if high is None else high
+            if self.diverging:
+                if low is None and high is None:
+                    bound = np.abs(values).max()
+                elif low is None:
+                    bound = abs(high)
+                elif high is None:
+                    bound = abs(low)
+                else:
+                    bound = max(abs(low), abs(high))
+                low, high = -bound, bound
+            norm = (LogNorm if self.cbar_log else Normalize)(vmin=low, vmax=high)
+        norm.autoscale_None(values)
+        if isinstance(norm, LogNorm) and (norm.vmin <= 0 or norm.vmax <= 0):
+            raise ValueError(
+                "shared logarithmic colorbar requires positive limits and data"
+            )
+        for image in images:
+            image.set_norm(norm)
+            image.set_cmap(images[0].get_cmap())
+
+    def _pad_figure(self, left=0, right=0, bottom=0, top=0):
+        """Grow the canvas while retaining axes sizes and spacing in inches."""
+        width, height = self.fig.get_size_inches()
+        new_width, new_height = width + left + right, height + bottom + top
+        positions = [ax.get_position(original=True).bounds for ax in self.fig.axes]
+        self.fig.set_size_inches(new_width, new_height)
+        for ax, (x, y, w, h) in zip(self.fig.axes, positions):
+            ax.set_position(
+                (
+                    (x * width + left) / new_width,
+                    (y * height + bottom) / new_height,
+                    w * width / new_width,
+                    h * height / new_height,
+                )
+            )
+
+    def _add_shared_colorbar(self):
+        """Place a colorbar outside the grid without stealing image space."""
+        axes = list(self.axes.flat)[: self._nimages]
+        boxes = [ax.get_position() for ax in axes]
+        width, height = self.fig.get_size_inches()
+        horizontal = self.orientation in ("h", "horizontal")
+        if horizontal:
+            x = min(box.x0 for box in boxes) * width
+            span = (max(box.x1 for box in boxes) - min(box.x0 for box in boxes)) * width
+            self._pad_figure(bottom=0.3)
+            rect = (x / width, 0, span / width, 0.15 / (height + 0.3))
+        else:
+            y = min(box.y0 for box in boxes) * height
+            span = (
+                max(box.y1 for box in boxes) - min(box.y0 for box in boxes)
+            ) * height
+            self._pad_figure(right=0.3)
+            rect = (
+                (width + 0.15) / (width + 0.3),
+                y / height,
+                0.15 / (width + 0.3),
+                span / height,
+            )
+        self.cbar_ax = self.fig.add_axes(rect)
+        image = axes[0].images[0]
+        extend = "neither"
+        if self.robust:
+            extend = (
+                "both"
+                if self.vmin is None and self.vmax is None
+                else (
+                    "min"
+                    if self.vmin is None
+                    else "max" if self.vmax is None else "neither"
+                )
+            )
+        self.colorbar = self.fig.colorbar(
+            image,
+            cax=self.cbar_ax,
+            orientation="horizontal" if horizontal else "vertical",
+            extend=extend,
+        )
+        if self.cbar_ticks is not None:
+            self.colorbar.set_ticks(self.cbar_ticks)
+        if self.cbar_label is not None:
+            self.colorbar.set_label(self.cbar_label)
+        if self.despine is not False:
+            self.colorbar.outline.set_visible(False)
+        # Include tick labels and axis labels in the canvas, not just the bar.
+        self.fig.canvas.draw()
+        box = self.cbar_ax.get_tightbbox()
+        width, height = self.fig.get_size_inches()
+        self._pad_figure(
+            left=max(0, -box.x0 / self.fig.dpi),
+            right=max(0, box.x1 / self.fig.dpi - width),
+            bottom=max(0, -box.y0 / self.fig.dpi),
+            top=max(0, box.y1 / self.fig.dpi - height),
+        )
 
     def _check_len_wrt_n_images(self, param_list):
         """If a specific parameter is supplied as a list/tuple, check that the

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1292,6 +1292,161 @@ def test_image_grid_default_retains_layout(auto, constrained, kwargs, monkeypatc
     assert engines == ["TightLayoutEngine" if auto else "ConstrainedLayoutEngine"]
 
 
+@pytest.mark.parametrize("gap", [None, 0, 0.1])
+@pytest.mark.parametrize("orientation", ["v", "h"])
+def test_shared_colorbar_preserves_image_geometry(gap, orientation):
+    data = [np.arange(800).reshape(20, 40) + i * 100 for i in range(5)]
+    plain = isns.ImageGrid(data, cbar=False, gap=gap, height=1, col_wrap=3)
+    g = isns.ImageGrid(
+        data,
+        cbar="shared",
+        gap=gap,
+        height=1,
+        col_wrap=3,
+        orientation=orientation,
+        cbar_label="Intensity",
+        cbar_ticks=[0, 600, 1200],
+    )
+    try:
+        plain.fig.canvas.draw()
+        for _ in range(2):
+            g.fig.canvas.draw()
+            boxes = np.array([ax.get_window_extent().bounds for ax in g.axes.flat])
+            original = np.array(
+                [ax.get_window_extent().bounds for ax in plain.axes.flat]
+            )
+            # All axes receive the same translation; no sizes or gaps change.
+            np.testing.assert_allclose(boxes[:, 2:], original[:, 2:], atol=1e-8)
+            np.testing.assert_allclose(
+                boxes[:, :2] - boxes[0, :2],
+                original[:, :2] - original[0, :2],
+                atol=1e-8,
+            )
+        images = [ax.images[0] for ax in list(g.axes.flat)[:5]]
+        assert all(im.norm is images[0].norm for im in images)
+        assert all(im.get_cmap() is images[0].get_cmap() for im in images)
+        assert images[0].get_clim() == (0, 1199)
+        np.testing.assert_allclose(images[0].to_rgba(500), images[-1].to_rgba(500))
+        assert len(g.fig.axes) == g.axes.size + 1
+        assert g.colorbar.ax is g.cbar_ax
+        np.testing.assert_array_equal(g.colorbar.get_ticks(), [0, 600, 1200])
+        box = g.cbar_ax.get_tightbbox(g.fig.canvas.get_renderer())
+        assert box.x0 >= -1e-8 and box.y0 >= -1e-8
+        assert box.x1 <= g.fig.bbox.width + 1e-8
+        assert box.y1 <= g.fig.bbox.height + 1e-8
+    finally:
+        plt.close(plain.fig)
+        plt.close(g.fig)
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ({}, (1, 100)),
+        ({"vmin": 0, "vmax": 200}, (0, 200)),
+        ({"vmin": 0}, (0, 100)),
+        ({"robust": True, "perc": (25, 75)}, (1, 25.75)),
+        ({"diverging": True}, (-100, 100)),
+        ({"diverging": True, "vmax": 50}, (-50, 50)),
+        ({"cbar_log": True}, (1, 100)),
+        ({"norm": colors.Normalize(vmin=0)}, (0, 100)),
+    ],
+)
+def test_shared_colorbar_normalization(kwargs, expected):
+    g = isns.ImageGrid([np.ones((1, 3)), np.array([[100.0]])], cbar="shared", **kwargs)
+    try:
+        image = g.axes.flat[0].images[0]
+        assert image.get_clim() == expected
+        if "norm" in kwargs:
+            assert image.norm is kwargs["norm"]
+        if kwargs.get("cbar_log"):
+            assert isinstance(image.norm, colors.LogNorm)
+        if kwargs.get("robust"):
+            assert g.colorbar.extend == "both"
+    finally:
+        plt.close(g.fig)
+
+
+def test_shared_colorbar_selected_transformed_data():
+    data = np.stack([np.full((4, 4), n) for n in (1, 2, 999)], axis=-1)
+    g = isns.ImageGrid(data, slices=[0, 1], map_func=lambda x: x * 10, cbar="shared")
+    try:
+        assert g.colorbar.mappable.get_clim() == (10, 20)
+    finally:
+        plt.close(g.fig)
+
+
+def test_shared_colorbar_ignores_masked_and_nonfinite_values():
+    data = [
+        np.ma.array([[1, 999]], mask=[[False, True]]),
+        np.array([[2, np.nan, np.inf]]),
+    ]
+    g = isns.ImageGrid(data, cbar="shared")
+    try:
+        assert g.colorbar.mappable.get_clim() == (1, 2)
+    finally:
+        plt.close(g.fig)
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"cmap": ["gray", "viridis"]}, "single cmap"),
+        ({"vmin": [0, 1]}, "single vmin"),
+        ({"norm": colors.Normalize(), "vmin": 0}, "shared norm"),
+        ({"norm": colors.Normalize(), "robust": True}, "shared norm"),
+        ({"perc": [(2, 98), (2, 98)]}, "percentile pair"),
+        ({"orientation": "bad"}, "orientation"),
+    ],
+)
+def test_shared_colorbar_rejects_conflicting_settings(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        isns.ImageGrid([np.ones((4, 4))] * 2, cbar="shared", **kwargs)
+
+
+@pytest.mark.parametrize(
+    "data,match",
+    [
+        ([np.ones((4, 4, 3))], "scalar images"),
+        ([np.ones((4, 4, 4))], "scalar images"),
+        ([np.full((4, 4), np.nan)], "finite, unmasked"),
+    ],
+)
+def test_shared_colorbar_rejects_unsupported_images(data, match):
+    figures = plt.get_fignums()
+    with pytest.raises(ValueError, match=match):
+        isns.ImageGrid(data, cbar="shared")
+    assert plt.get_fignums() == figures
+
+
+@pytest.mark.parametrize("gap", [None, 0])
+@pytest.mark.parametrize(
+    "setting", ["figure.autolayout", "figure.constrained_layout.use"]
+)
+def test_shared_colorbar_with_layout_defaults(gap, setting):
+    with matplotlib.rc_context({setting: True}):
+        g = isns.ImageGrid(
+            [np.arange(8).reshape(2, 4)] * 4, gap=gap, cbar="shared", col_wrap=2
+        )
+        try:
+            for _ in range(2):
+                g.fig.canvas.draw()
+                a, b, c, _ = [ax.get_window_extent() for ax in g.axes.flat]
+                if gap == 0:
+                    assert b.x0 - a.x1 == pytest.approx(0, abs=1e-8)
+                    assert a.y0 - c.y1 == pytest.approx(0, abs=1e-8)
+                assert g.cbar_ax.get_window_extent().x0 > b.x1
+        finally:
+            plt.close(g.fig)
+
+
+def test_shared_colorbar_invalid_log_data_closes_figure():
+    figures = plt.get_fignums()
+    with pytest.raises(ValueError, match="positive limits and data"):
+        isns.ImageGrid([np.full((4, 4), -1)], cbar="shared", cbar_log=True)
+    assert plt.get_fignums() == figures
+
+
 def test_FilterGrid_deprecation_warning():
     with pytest.warns(UserWarning, match="FilterGrid is depracted"):
         _ = isns.FilterGrid(


### PR DESCRIPTION
## Stack
Depends on #889. This PR targets feat/image-grid-gap so its diff contains only shared-colorbar work. Merge #889 first, then retarget this PR to master.

## Summary
- Add cbar="shared" with one normalization and colormap across selected, transformed scalar images.
- Support global limits, pooled robust percentiles, diverging/logarithmic scales, and supplied Normalize instances.
- Place one vertical or horizontal bar outside the grid, preserving image dimensions and zero/positive gaps; support default automatic spacing too.
- Expose colorbar and cbar_ax, reuse labels/ticks/orientation, and reject incompatible per-image settings and RGB/RGBA data.
- Add a gallery example and rendered-geometry/normalization regression tests.

## Verification
- Full pytest suite: 9671 passed, 4 warnings.
- After final PDF-backend compatibility fix: grid suite 121 passed, 4 warnings.
- xdoctest: 15 passed, 2 warnings.
- PDF backend construction and export passed.
- Inspected automatic-spacing vertical, zero-gap horizontal robust, and positive-gap logarithmic exports.

## Limits
Explicit gaps retain the existing initial-figure-size contract; later resizing/layout calls may change spacing. Shared colorbars require scalar images representing comparable quantities.