### PR TITLE
Derive package versions from Git release tags

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
     - uses: astral-sh/setup-uv@v10.0.1
       with:
         python-version: "3.12"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v10.0.1
         with:
           python-version: "3.12"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+      with:
+        ref: ${{ github.event.release.tag_name }}
+        fetch-depth: 0
     - uses: astral-sh/setup-uv@v10.0.1
       with:
         python-version: "3.12"
         enable-cache: true
     - run: uv sync --locked --no-default-groups --group test
+    - name: Verify package version matches release tag
+      env:
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
+      run: |
+        uv run --no-sync python - <<'PY'
+        import os
+        from importlib.metadata import version
+        from packaging.version import Version
+
+        expected = Version(os.environ["RELEASE_TAG"])
+        actual = Version(version("seaborn-image"))
+        if actual != expected:
+            raise SystemExit(f"Package version {actual} does not match release tag {expected}")
+        PY
     - run: uv run pytest
     - run: uv run python -m xdoctest --modname=seaborn_image --command=all
     - run: uv build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v10.0.1
         with:
           python-version: ${{ matrix.python-version }}

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -137,6 +137,27 @@ This will allow a chance to talk it over and validate your approach.
 .. _pre-commit: https://pre-commit.com/
 
 
+How to publish a release
+------------------------
+
+Create and publish a GitHub Release with a version tag such as ``v0.11.0``
+or ``0.11.0`` (prereleases such as ``v0.11.0rc1`` also work).
+Use a valid Python package version that has not already been published to PyPI.
+Creating a tag alone or saving a draft release does not publish the package.
+
+The package version is dynamic: ``hatch-vcs`` derives it from Git tags rather
+than a hard-coded value in ``pyproject.toml``. The release workflow checks out
+the tag with full history, verifies that the installed version matches it,
+runs the tests, and builds and publishes the wheel and source distribution.
+No manual version bump or automated version commit is required.
+
+Development builds between tags receive a development version. Use a Git
+checkout with tags and full history (run ``git fetch --unshallow --tags`` if
+your clone is shallow). Source distributions published to PyPI retain their
+version and can be built without Git; GitHub source ZIP downloads are not a
+substitute for those distributions.
+
+
 Credits
 -------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "seaborn-image"
-version = "0.10.1"
+dynamic = ["version"]
 description = "Attractive, descriptive and effective image visualization with seaborn-like API built on top of matplotlib"
 readme = "README.md"
 license = "MIT"
@@ -61,6 +61,10 @@ dev = [
 
 [tool.uv]
 default-groups = ["dev"]
+cache-keys = [{ file = "pyproject.toml" }, { git = { commit = true, tags = true } }]
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.hatch.build.targets.sdist]
 only-include = ["src/seaborn_image"]

--- a/uv.lock
+++ b/uv.lock
@@ -2828,7 +2828,6 @@ wheels = [
 
 [[package]]
 name = "seaborn-image"
-version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Changes
Use hatch-vcs to derive package metadata from Git tags instead of maintaining a hard-coded version in pyproject.toml. Publishing a GitHub Release remains the PyPI publication trigger; no automated version-bump commits are needed.

Fetch full history in build workflows, invalidate uv metadata caches when commits or tags change, and verify the installed package version matches the release tag before publishing. Document the release and development versioning behavior.

## Verification
- 9,671 pytest tests passed (4 warnings).
- All 15 xdoctests passed (2 warnings).
- Locked installs and builds succeeded for v0.11.0, 0.11.1, and v0.12.0rc1 in a temporary Git repository; wheel and sdist metadata matched each tag without changing uv.lock.
- Release validation rejected an invalid version and a mismatched tag.
- A standalone source distribution rebuilt without Git.
- A development commit produced a development version on reinstall.
- git diff --check passed.

No package was published during verification.