### PR TITLE
docs: add See Also sections to public API docstrings

### DIFF
--- a/src/seaborn_image/_context.py
+++ b/src/seaborn_image/_context.py
@@ -34,6 +34,12 @@ def set_context(mode="paper", fontfamily="sans-serif", fontweight="normal", rc=N
     rc : dict, optional
         Additional `matplotlib.rcParams` to be passed to matplotlib, by default None.
 
+    See Also
+    --------
+    seaborn_image.set_image : Set defaults for image rendering.
+    seaborn_image.set_save_context : Set the resolution of saved figures.
+    seaborn_image.reset_defaults : Restore Matplotlib defaults.
+
     Examples
     --------
         >>> import seaborn_image as isns
@@ -79,6 +85,11 @@ def set_save_context(dpi=300):
     dpi : int, optional
         Image dpi for saving, by default 300.
 
+    See Also
+    --------
+    seaborn_image.set_context : Set fonts and plotting context.
+    seaborn_image.reset_defaults : Restore Matplotlib defaults.
+
     Examples
     --------
         >>> import seaborn_image as isns
@@ -90,6 +101,13 @@ def set_save_context(dpi=300):
 def reset_defaults():
     """
     Reset rcParams to matplotlib defaults
+
+    See Also
+    --------
+    seaborn_image.set_context : Set fonts and plotting context.
+    seaborn_image.set_image : Set defaults for image rendering.
+    seaborn_image.set_scalebar : Set default scalebar properties.
+    seaborn_image.set_save_context : Set the resolution of saved figures.
 
     Examples
     --------
@@ -113,6 +131,12 @@ def set_image(cmap="deep", origin="upper", interpolation="nearest", despine=Fals
         Image interpolation - same as in `matplotlib.pyplot.imshow`, by default "nearest".
     despine : bool, optional
         Despine image and colorbar axes, by default False.
+
+    See Also
+    --------
+    seaborn_image.imgplot : Plot an image using the rendering defaults.
+    seaborn_image.despine : Remove spines from existing axes or figures.
+    seaborn_image.reset_defaults : Restore Matplotlib defaults.
 
     Examples
     --------
@@ -187,6 +211,12 @@ def set_scalebar(
             the scalebar artist, by default 0.
         rc : dict, optional
             Dictionary of scalebar properties to be set, by default None.
+
+    See Also
+    --------
+    seaborn_image.imgplot : Plot an image with a scalebar using dx and units.
+    seaborn_image.set_image : Set defaults for image rendering.
+    seaborn_image.reset_defaults : Restore Matplotlib defaults.
 
     Examples
     --------

--- a/src/seaborn_image/_datasets.py
+++ b/src/seaborn_image/_datasets.py
@@ -39,6 +39,11 @@ def load_image(name):
     `numpy.ndarray`
         Image data as a `numpy` array
 
+    See Also
+    --------
+    seaborn_image.imgplot : Plot a loaded image.
+    seaborn_image.ImageGrid : Plot a loaded image collection or multidimensional data.
+
     Examples
     --------
     >>> import seaborn_image as isns

--- a/src/seaborn_image/_filters.py
+++ b/src/seaborn_image/_filters.py
@@ -151,6 +151,12 @@ def filterplot(
     TypeError
         if `describe` is not a `bool`
 
+    See Also
+    --------
+    seaborn_image.imgplot : Plot an image without applying a filter.
+    seaborn_image.ParamGrid : Compare filter parameters across a grid of images.
+    seaborn_image.fftplot : Visualize the Fourier transform of an image.
+
     Examples
     --------
 
@@ -300,6 +306,11 @@ def fftplot(
     ------
     ValueError
         If input image is RGB image
+
+    See Also
+    --------
+    seaborn_image.imgplot : Plot an image in the spatial domain.
+    seaborn_image.filterplot : Apply a filter and plot the result.
 
     Examples
     --------

--- a/src/seaborn_image/_general.py
+++ b/src/seaborn_image/_general.py
@@ -154,6 +154,13 @@ def imgplot(
     AssertionError
         if the first element of `perc` is greater than the second
 
+    See Also
+    --------
+    seaborn_image.imghist : Plot an image alongside its intensity histogram.
+    seaborn_image.ImageGrid : Plot a collection of images or slices in a grid.
+    seaborn_image.rgbplot : Plot the red, green, and blue channels separately.
+    seaborn_image.filterplot : Apply a filter and plot the result.
+
     Examples
     --------
 
@@ -515,6 +522,12 @@ def imghist(
     ------
     TypeError
         if `bins` is not a positive integer
+
+    See Also
+    --------
+    seaborn_image.imgplot : Plot an image without a histogram.
+    seaborn_image.ImageGrid : Plot a collection of images or slices in a grid.
+    seaborn_image.scientific_ticks : Format axis ticks in scientific notation.
 
     Examples
     --------

--- a/src/seaborn_image/_grid.py
+++ b/src/seaborn_image/_grid.py
@@ -159,6 +159,12 @@ class ImageGrid:
     ValueError
         If `map_func` is a list/tuple of callable objects when `data` is 3D or 4D
 
+    See Also
+    --------
+    seaborn_image.imgplot : Plot a single image on an axes.
+    seaborn_image.rgbplot : Split an RGB image into a grid of color channels.
+    seaborn_image.ParamGrid : Compare function parameters across a grid of images.
+
     Examples
     --------
 
@@ -1094,6 +1100,11 @@ def rgbplot(
     ValueError
         If `data` channels are not 3
 
+    See Also
+    --------
+    seaborn_image.imgplot : Plot an RGB image without splitting its channels.
+    seaborn_image.ImageGrid : Plot a collection of images or slices in a grid.
+
     Examples
     --------
 
@@ -1274,6 +1285,11 @@ class ParamGrid(object):
         If `col` is specified without passing the parameter as a keyword argument
     ValueError
         If `col_wrap` is specified when `row` is not `None`
+
+    See Also
+    --------
+    seaborn_image.filterplot : Apply a filter with one set of parameters.
+    seaborn_image.ImageGrid : Plot a collection of images or slices in a grid.
 
     Examples
     --------
@@ -1588,7 +1604,12 @@ class ParamGrid(object):
 
 
 class FilterGrid:
-    """Deprecated - use `ParamGrid` instead."""
+    """Deprecated - use `ParamGrid` instead.
+
+    See Also
+    --------
+    seaborn_image.ParamGrid : Compare function parameters across a grid of images.
+    """
 
     def __init__(self, *args, **kwargs):
         warnings.warn(

--- a/src/seaborn_image/utils.py
+++ b/src/seaborn_image/utils.py
@@ -25,6 +25,11 @@ def scientific_ticks(ax, which="y"):
     ValueError
         If `which` is not one of ['y', 'x', 'both']
 
+    See Also
+    --------
+    seaborn_image.imgplot : Plot an image with an optional colorbar.
+    seaborn_image.imghist : Plot an image alongside its intensity histogram.
+
     Examples
     --------
 
@@ -89,6 +94,11 @@ def despine(fig=None, ax=None, which="all"):
         ["all", "top", "bottom", "right", "left"]
     TypeError
         If `which` is not a str or list
+
+    See Also
+    --------
+    seaborn_image.set_image : Set default spine visibility for new plots.
+    seaborn_image.imgplot : Plot an image with an option to remove spines.
 
     Examples
     --------


### PR DESCRIPTION
Closes #288.

Add NumPy-style See Also sections with linked descriptions of related public APIs. Covers all 17 public functions and classes, including imshow through its inherited imgplot docstring. No runtime behavior changes.

Verification:
- Built the HTML API documentation with Sphinx.
- Checked all 17 rendered sections and verified that all 45 links resolve to existing API anchors.
- Inspected the rendered imgplot section and followed its ImageGrid link in Chromium.
- Confirmed Python structure is unchanged apart from string content.
- git diff --check passes.

The full documentation build requires Pandoc, which is unavailable in the orb. The successful build excluded tutorial notebooks and disabled gallery execution, producing seven expected missing-tutorial warnings. Runtime tests were not run for this documentation-only change.