### PR TITLE
Add `pipelineplot` with accessible intermediate images

### DIFF
--- a/docs/api/pipelineplot.rst
+++ b/docs/api/pipelineplot.rst
@@ -1,0 +1,4 @@
+seaborn_image.pipelineplot
+=========================
+
+.. autofunction:: seaborn_image.pipelineplot

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -10,6 +10,7 @@ Reference
    api/ImageGrid
    api/rgbplot
    api/filterplot
+   api/pipelineplot
    api/fftplot
    api/ParamGrid
    api/datasets
@@ -51,6 +52,13 @@ Figure level function to visualize RGB channels in a RGB image.
 ----------------------------------
 
 Axes level function to apply image filters and visualize them.
+
+
+:doc:`pipelineplot <api/pipelineplot>`
+------------------------------------
+
+Apply named processing steps sequentially, visualize each stage, and retain
+the resulting arrays in ``pipeline.images``.
 
 
 :doc:`fftplot <api/fftplot>`

--- a/src/seaborn_image/__init__.py
+++ b/src/seaborn_image/__init__.py
@@ -5,6 +5,7 @@ from ._context import *
 from ._general import *
 from ._filters import *
 from ._grid import *
+from ._pipeline import *
 from .utils import *
 from ._datasets import *
 

--- a/src/seaborn_image/_pipeline.py
+++ b/src/seaborn_image/_pipeline.py
@@ -1,0 +1,103 @@
+import numpy as np
+
+from ._grid import ImageGrid
+
+__all__ = ["pipelineplot"]
+
+
+def _snapshot_image(data):
+    image = np.array(data, copy=True)
+    if image.ndim != 2 and not (image.ndim == 3 and image.shape[-1] in (3, 4)):
+        raise ValueError("pipeline images must be 2-D grayscale or RGB/RGBA arrays")
+    if not image.size:
+        raise ValueError("pipeline images must not be empty")
+    return image
+
+
+def pipelineplot(data, steps, *, include_original=True, **grid_kws):
+    """Apply named processing steps sequentially and plot every result.
+
+    Parameters
+    ----------
+    data : array-like
+        A 2-D grayscale or RGB/RGBA image. The input is not modified.
+    steps : sequence of (str, callable, dict)
+        Ordered triples of panel label, function, and keyword arguments.
+        Each function receives the preceding image as its first argument and
+        must return an image. Use an empty dictionary for no arguments.
+        At least one step is required. Functions may change image shape.
+    include_original : bool, optional
+        Include the original as the first panel and first entry in ``images``.
+        Defaults to True.
+    **grid_kws
+        Display options forwarded to :class:`ImageGrid`, such as ``col_wrap``,
+        ``cmap``, ``cbar``, ``vmin``, and ``vmax``. Mapping and slicing options
+        are not supported. Per-panel options include the original when shown.
+        Color limits default to independent scaling; pass ``vmin`` and
+        ``vmax`` explicitly to compare stages on a shared intensity scale.
+
+    Returns
+    -------
+    pipeline : ImageGrid
+        Grid with ``fig``, ``axes``, and ``images`` attributes. ``images`` is
+        a list of image arrays in panel order, before display normalization.
+        Each array is a snapshot: later steps, including in-place filters,
+        cannot overwrite earlier results. ``images[-1]`` is the final result.
+        Editing these arrays after plotting does not update the figure.
+
+    Examples
+    --------
+    >>> import seaborn_image as isns
+    >>> from skimage import data, filters
+    >>> pipeline = isns.pipelineplot(
+    ...     data.coins(),
+    ...     steps=[
+    ...         ("Gaussian (sigma=2)", filters.gaussian, {"sigma": 2}),
+    ...         ("Sobel", filters.sobel, {}),
+    ...     ],
+    ...     cmap="gray", cbar=False,
+    ... )
+    >>> edges = pipeline.images[-1]
+    """
+    if not isinstance(include_original, bool):
+        raise TypeError("include_original must be a bool")
+    if not isinstance(steps, (list, tuple)) or not steps:
+        raise ValueError("steps must be a non-empty list or tuple of triples")
+    for step in steps:
+        if not isinstance(step, (list, tuple)) or len(step) != 3:
+            raise ValueError("each step must be a (label, callable, kwargs) triple")
+        label, func, kwargs = step
+        if (
+            not isinstance(label, str)
+            or not callable(func)
+            or not isinstance(kwargs, dict)
+        ):
+            raise TypeError("each step requires a string label, callable, and dict")
+    unsupported = set(grid_kws) & {
+        "map_func",
+        "map_func_kw",
+        "slices",
+        "axis",
+        "step",
+        "start",
+        "stop",
+    }
+    if unsupported:
+        raise TypeError(
+            f"pipelineplot does not support: {', '.join(sorted(unsupported))}"
+        )
+
+    current = _snapshot_image(data)
+    images = [current] if include_original else []
+    labels = ["Original"] if include_original else []
+    for label, func, kwargs in steps:
+        current = _snapshot_image(func(current.copy(), **kwargs))
+        images.append(current)
+        labels.append(label)
+
+    pipeline = ImageGrid(images, **grid_kws)
+    pipeline.images = images
+    for ax, label in zip(pipeline.axes.flat, labels):
+        ax.set_title(label)
+    pipeline.fig.tight_layout()
+    return pipeline

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,108 @@
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+import seaborn_image as isns
+
+
+@pytest.fixture(autouse=True)
+def close_figures():
+    yield
+    plt.close("all")
+
+
+@pytest.mark.parametrize("include_original", [True, False])
+def test_sequential_images_and_panels(include_original):
+    source = np.array([[1.0, 4.0, 2.0], [3.0, 0.0, 5.0]])
+    calls = []
+
+    def add(image, amount):
+        calls.append("add")
+        image += amount
+        return image
+
+    def multiply(image, factor):
+        calls.append("multiply")
+        image *= factor
+        return image
+
+    pipeline = isns.pipelineplot(
+        source,
+        [("Add", add, {"amount": 2}), ("Multiply", multiply, {"factor": 3})],
+        include_original=include_original,
+        col_wrap=2,
+        cbar=False,
+        cmap="gray",
+        vmin=0,
+        vmax=21,
+    )
+    expected = [
+        np.array([[3.0, 6.0, 4.0], [5.0, 2.0, 7.0]]),
+        np.array([[9.0, 18.0, 12.0], [15.0, 6.0, 21.0]]),
+    ]
+    labels = ["Add", "Multiply"]
+    if include_original:
+        expected.insert(0, source)
+        labels.insert(0, "Original")
+    assert calls == ["add", "multiply"]
+    assert isinstance(pipeline, isns.ImageGrid)
+    assert len(pipeline.images) == len(expected)
+    for image, ax, result, label in zip(
+        pipeline.images, pipeline.axes.flat, expected, labels
+    ):
+        np.testing.assert_array_equal(image, result)
+        np.testing.assert_array_equal(ax.images[0].get_array(), result)
+        assert ax.get_title() == label
+        assert ax.images[0].get_clim() == (0, 21)
+        assert not np.shares_memory(image, source)
+    np.testing.assert_array_equal(source, [[1, 4, 2], [3, 0, 5]])
+    pipeline.images[-1][:] = 0
+    np.testing.assert_array_equal(pipeline.images[-2], expected[-2])
+
+
+def test_rgb_to_grayscale_and_single_panel():
+    source = np.arange(24).reshape(2, 4, 3) / 24
+    pipeline = isns.pipelineplot(
+        source,
+        [("Red channel", lambda image: image[:, :, 0], {})],
+        include_original=False,
+        cbar=False,
+    )
+    assert pipeline.axes.shape == (1, 1)
+    np.testing.assert_array_equal(pipeline.images[0], source[:, :, 0])
+
+
+@pytest.mark.parametrize(
+    "steps, error",
+    [
+        ([], ValueError),
+        ([("Incomplete", np.negative)], ValueError),
+        ([("Not callable", "gaussian", {})], TypeError),
+        ([("Bad kwargs", np.negative, None)], TypeError),
+        ([(1, np.negative, {})], TypeError),
+    ],
+)
+def test_invalid_steps(steps, error):
+    with pytest.raises(error):
+        isns.pipelineplot(np.ones((2, 3)), steps)
+
+
+@pytest.mark.parametrize(
+    "data", [None, np.ones(3), np.ones((2, 3, 2)), np.empty((0, 3))]
+)
+def test_invalid_input_or_output(data):
+    with pytest.raises(ValueError, match="pipeline images"):
+        isns.pipelineplot(data, [("Identity", lambda image: image, {})])
+    with pytest.raises(ValueError, match="pipeline images"):
+        isns.pipelineplot(np.ones((2, 3)), [("Invalid", lambda image: data, {})])
+
+
+def test_reject_mapping_options():
+    with pytest.raises(TypeError, match="map_func"):
+        isns.pipelineplot(
+            np.ones((2, 3)), [("Negative", np.negative, {})], map_func=np.negative
+        )


### PR DESCRIPTION
## What this adds

Adds `isns.pipelineplot` to run named image-processing steps sequentially and visualize each result using `ImageGrid`.

```python
import seaborn_image as isns
from skimage import data, filters

pipeline = isns.pipelineplot(
    data.coins(),
    steps=[
        ("Gaussian", filters.gaussian, {"sigma": 2}),
        ("Sobel", filters.sobel, {}),
    ],
    cmap="gray",
    cbar=False,
)
edges = pipeline.images[-1]
```

`pipeline.images` holds independent snapshots in panel order, including the original by default. `include_original=False` omits it from both the plot and the returned list. In-place filters cannot overwrite earlier stages or modify the input. The returned grid exposes `fig` and `axes`, and accepts existing grid display options.

Includes API documentation and tests for sequential execution, kwargs routing, snapshot isolation, RGB-to-grayscale processing, plotting options, and invalid inputs.

Related to #41. This implements sequential pipeline visualization; independent filter comparison remains available through `ImageGrid`.

## Verification

- Full suite: `pytest -q` — 9,607 passed, with one existing figure-count warning from the grid tests.
- New pipeline tests: 13 passed.
- Updated docstring: 4 doctest examples passed.
- Rendered and inspected default output and an original-hidden, vertically wrapped layout with colorbars.
- `git diff --check` passed.